### PR TITLE
refactor: DART/KRX Silver pipelines, Scorer ABC, test coverage

### DIFF
--- a/data/gold/aggregation_test.py
+++ b/data/gold/aggregation_test.py
@@ -1,0 +1,234 @@
+"""Tests for Gold aggregation — public interface only."""
+
+import pandas as pd
+import pytest
+
+from data.gold.aggregation import TTMCalculator
+from data.gold.aggregation import YTDToQuarterlyConverter
+
+
+def _make_ytd_facts(cik10: str, metric: str,
+                    rows: list[dict]) -> pd.DataFrame:
+  """Build a facts DataFrame for testing.
+
+  Each row dict should have: fy, fp, fiscal_quarter, val, filed.
+  """
+  records = []
+  qtr_month = {'Q1': '03-31', 'Q2': '06-30', 'Q3': '09-30', 'FY': '12-31'}
+  for r in rows:
+    fp = r['fp']
+    end = pd.Timestamp(f"{r['fy']}-{qtr_month[fp]}")
+    records.append({
+        'cik10': cik10,
+        'metric': metric,
+        'val': r['val'],
+        'end': end,
+        'filed': pd.Timestamp(r['filed']),
+        'fy': str(r['fy']),
+        'fp': fp,
+        'fiscal_year': r['fy'],
+        'fiscal_quarter': r.get('fiscal_quarter', 'Q4' if fp == 'FY' else fp),
+        'tag': f'tag_{metric}',
+    })
+  return pd.DataFrame(records)
+
+
+class TestYTDToQuarterlyConverter:
+  """YTDToQuarterlyConverter.convert() public interface tests."""
+
+  def test_q1_uses_raw_value(self):
+    """Q1 has no prior quarter to subtract — q_val == val."""
+    facts = _make_ytd_facts('AAPL', 'CFO', [{
+        'fy': 2024, 'fp': 'Q1', 'val': 100.0,
+        'filed': '2024-05-01',
+    }])
+    result = YTDToQuarterlyConverter().convert(facts)
+
+    assert len(result) == 1
+    assert result.iloc[0]['q_val'] == 100.0
+
+  def test_q2_subtracts_q1_ytd(self):
+    """Q2 quarterly = Q2_YTD - Q1_YTD."""
+    facts = _make_ytd_facts('AAPL', 'CFO', [
+        {'fy': 2024, 'fp': 'Q1', 'val': 100.0, 'filed': '2024-05-01'},
+        {'fy': 2024, 'fp': 'Q2', 'val': 250.0, 'filed': '2024-08-01'},
+    ])
+    result = YTDToQuarterlyConverter().convert(facts)
+    q2 = result[result['fiscal_quarter'] == 'Q2']
+
+    assert len(q2) == 1
+    assert q2.iloc[0]['q_val'] == 150.0
+
+  def test_fy_subtracts_q3_ytd(self):
+    """FY (Q4) quarterly = FY_YTD - Q3_YTD."""
+    facts = _make_ytd_facts('AAPL', 'CFO', [
+        {'fy': 2024, 'fp': 'Q1', 'val': 100.0, 'filed': '2024-05-01'},
+        {'fy': 2024, 'fp': 'Q2', 'val': 250.0, 'filed': '2024-08-01'},
+        {'fy': 2024, 'fp': 'Q3', 'val': 400.0, 'filed': '2024-11-01'},
+        {'fy': 2024, 'fp': 'FY', 'val': 600.0, 'filed': '2025-02-01',
+         'fiscal_quarter': 'Q4'},
+    ])
+    result = YTDToQuarterlyConverter().convert(facts)
+    q4 = result[result['fiscal_quarter'] == 'Q4']
+
+    assert len(q4) == 1
+    assert q4.iloc[0]['q_val'] == 200.0
+
+  def test_pit_only_uses_prior_quarter_filed_before(self):
+    """PIT: Q2 ignores Q1 filed after Q2's filed date."""
+    facts = _make_ytd_facts('AAPL', 'CFO', [
+        # Q1 filed AFTER Q2 — should not be used for subtraction
+        {'fy': 2024, 'fp': 'Q1', 'val': 100.0, 'filed': '2024-09-01'},
+        {'fy': 2024, 'fp': 'Q2', 'val': 250.0, 'filed': '2024-08-01'},
+    ])
+    result = YTDToQuarterlyConverter().convert(facts)
+    q2 = result[result['fiscal_quarter'] == 'Q2']
+
+    # Q1 filed after Q2, so Q2 should use raw value (no subtraction)
+    assert len(q2) == 1
+    assert q2.iloc[0]['q_val'] == 250.0
+
+  def test_non_ytd_metric_passes_through(self):
+    """Non-YTD metrics (e.g., SHARES) pass val as q_val directly."""
+    facts = _make_ytd_facts('AAPL', 'SHARES', [{
+        'fy': 2024, 'fp': 'Q1', 'val': 1_000_000.0,
+        'filed': '2024-05-01',
+    }])
+    result = YTDToQuarterlyConverter().convert(facts)
+
+    assert len(result) == 1
+    assert result.iloc[0]['q_val'] == 1_000_000.0
+
+  def test_negative_q_val_set_to_nan_when_abs(self):
+    """For abs=True metrics (CAPEX), negative q_val → NaN."""
+    facts = _make_ytd_facts('AAPL', 'CAPEX', [
+        {'fy': 2024, 'fp': 'Q1', 'val': 200.0, 'filed': '2024-05-01'},
+        # Q2 YTD < Q1 YTD → negative quarterly (restatement)
+        {'fy': 2024, 'fp': 'Q2', 'val': 150.0, 'filed': '2024-08-01'},
+    ])
+    result = YTDToQuarterlyConverter().convert(facts)
+    q2 = result[result['fiscal_quarter'] == 'Q2']
+
+    assert len(q2) == 1
+    assert pd.isna(q2.iloc[0]['q_val'])
+
+  def test_empty_input(self):
+    result = YTDToQuarterlyConverter().convert(pd.DataFrame())
+    assert result.empty
+
+  def test_unknown_metric_ignored(self):
+    """Metrics not in METRIC_SPECS are silently skipped."""
+    facts = _make_ytd_facts('AAPL', 'UNKNOWN_METRIC', [{
+        'fy': 2024, 'fp': 'Q1', 'val': 42.0,
+        'filed': '2024-05-01',
+    }])
+    result = YTDToQuarterlyConverter().convert(facts)
+    assert result.empty
+
+
+class TestTTMCalculator:
+  """TTMCalculator.calculate() public interface tests."""
+
+  def _make_quarterly(self, cik10: str, metric: str,
+                      rows: list[dict]) -> pd.DataFrame:
+    records = []
+    qtr_month = {
+        'Q1': '03-31', 'Q2': '06-30', 'Q3': '09-30', 'Q4': '12-31',
+    }
+    for r in rows:
+      fq = r['fiscal_quarter']
+      end = pd.Timestamp(f"{r['fy']}-{qtr_month[fq]}")
+      records.append({
+          'cik10': cik10,
+          'metric': metric,
+          'q_val': r['q_val'],
+          'end': end,
+          'filed': pd.Timestamp(r['filed']),
+          'fy': str(r['fy']),
+          'fp': r.get('fp', fq),
+          'fiscal_year': r['fy'],
+          'fiscal_quarter': fq,
+          'tag': f'tag_{metric}',
+      })
+    return pd.DataFrame(records)
+
+  def test_ttm_sums_four_quarters(self):
+    """TTM = sum of 4 consecutive quarters."""
+    df = self._make_quarterly('AAPL', 'CFO', [
+        {'fy': 2023, 'fiscal_quarter': 'Q1',
+         'q_val': 100, 'filed': '2023-05-01'},
+        {'fy': 2023, 'fiscal_quarter': 'Q2',
+         'q_val': 110, 'filed': '2023-08-01'},
+        {'fy': 2023, 'fiscal_quarter': 'Q3',
+         'q_val': 120, 'filed': '2023-11-01'},
+        {'fy': 2023, 'fiscal_quarter': 'Q4',
+         'q_val': 130, 'filed': '2024-02-01'},
+    ])
+    result = TTMCalculator().calculate(df)
+    q4 = result[result['fiscal_quarter'] == 'Q4']
+
+    assert len(q4) == 1
+    assert q4.iloc[0]['ttm_val'] == pytest.approx(460.0)
+
+  def test_ttm_nan_when_fewer_than_four_quarters(self):
+    """TTM is NaN when not all 4 quarters are available."""
+    df = self._make_quarterly('AAPL', 'CFO', [
+        {'fy': 2023, 'fiscal_quarter': 'Q1',
+         'q_val': 100, 'filed': '2023-05-01'},
+        {'fy': 2023, 'fiscal_quarter': 'Q2',
+         'q_val': 110, 'filed': '2023-08-01'},
+    ])
+    result = TTMCalculator().calculate(df)
+
+    assert result['ttm_val'].isna().all()
+
+  def test_ttm_crosses_year_boundary(self):
+    """TTM at Q2 2024 sums Q3 2023 + Q4 2023 + Q1 2024 + Q2 2024."""
+    df = self._make_quarterly('AAPL', 'CFO', [
+        {'fy': 2023, 'fiscal_quarter': 'Q1',
+         'q_val': 90, 'filed': '2023-05-01'},
+        {'fy': 2023, 'fiscal_quarter': 'Q2',
+         'q_val': 100, 'filed': '2023-08-01'},
+        {'fy': 2023, 'fiscal_quarter': 'Q3',
+         'q_val': 110, 'filed': '2023-11-01'},
+        {'fy': 2023, 'fiscal_quarter': 'Q4',
+         'q_val': 120, 'filed': '2024-02-01'},
+        {'fy': 2024, 'fiscal_quarter': 'Q1',
+         'q_val': 130, 'filed': '2024-05-01'},
+        {'fy': 2024, 'fiscal_quarter': 'Q2',
+         'q_val': 140, 'filed': '2024-08-01'},
+    ])
+    result = TTMCalculator().calculate(df)
+    q2_2024 = result[
+        (result['fiscal_year'] == 2024) &
+        (result['fiscal_quarter'] == 'Q2')]
+
+    # TTM = Q3_2023(110) + Q4_2023(120) + Q1_2024(130) + Q2_2024(140)
+    assert q2_2024.iloc[0]['ttm_val'] == pytest.approx(500.0)
+
+  def test_pit_only_uses_filed_before_current(self):
+    """TTM only includes quarters filed on or before the current row's filed."""
+    df = self._make_quarterly('AAPL', 'CFO', [
+        {'fy': 2023, 'fiscal_quarter': 'Q1',
+         'q_val': 100, 'filed': '2023-05-01'},
+        {'fy': 2023, 'fiscal_quarter': 'Q2',
+         'q_val': 110, 'filed': '2023-08-01'},
+        {'fy': 2023, 'fiscal_quarter': 'Q3',
+         'q_val': 120, 'filed': '2023-11-01'},
+        # Q4 filed very late — after Q1 2024
+        {'fy': 2023, 'fiscal_quarter': 'Q4',
+         'q_val': 130, 'filed': '2024-06-01'},
+        {'fy': 2024, 'fiscal_quarter': 'Q1',
+         'q_val': 140, 'filed': '2024-05-01'},
+    ])
+    result = TTMCalculator().calculate(df)
+    q1_2024 = result[
+        (result['fiscal_year'] == 2024) &
+        (result['fiscal_quarter'] == 'Q1')]
+
+    # Q4 2023 filed after Q1 2024 → not available → TTM is NaN
+    assert pd.isna(q1_2024.iloc[0]['ttm_val'])
+
+  def test_empty_input(self):
+    result = TTMCalculator().calculate(pd.DataFrame())
+    assert result.empty

--- a/data/gold/backtest/tests/panel_test.py
+++ b/data/gold/backtest/tests/panel_test.py
@@ -1,0 +1,53 @@
+"""Tests for BacktestPanelBuilder — public interface only."""
+
+from pathlib import Path
+
+import pytest
+
+SILVER_DIR = Path('data/silver/out')
+HAS_SILVER = (SILVER_DIR / 'sec' / 'facts_long.parquet').exists()
+
+
+@pytest.mark.skipif(not HAS_SILVER, reason='No Silver data')
+class TestBacktestPanelBuilder:
+
+  def test_build_returns_dataframe(self, tmp_path):
+    from data.gold.backtest.panel import \
+        BacktestPanelBuilder  # pylint: disable=import-outside-toplevel
+    builder = BacktestPanelBuilder(
+        silver_dir=SILVER_DIR, gold_dir=tmp_path)
+    panel = builder.build()
+
+    assert not panel.empty
+    assert 'ticker' in panel.columns
+    assert 'end' in panel.columns
+    assert 'filed' in panel.columns
+
+  def test_primary_key_allows_multiple_filed_per_end(self, tmp_path):
+    """Backtest panel keeps all filed versions — not just latest."""
+    from data.gold.backtest.panel import \
+        BacktestPanelBuilder  # pylint: disable=import-outside-toplevel
+    builder = BacktestPanelBuilder(
+        silver_dir=SILVER_DIR, gold_dir=tmp_path)
+    panel = builder.build()
+
+    # For the same ticker+end, there should be multiple filed dates
+    # (at least for some tickers with restatements or amended filings)
+    grouped = panel.groupby(['ticker', 'end'])['filed'].nunique()
+    # At minimum, every group has at least 1 filed
+    assert (grouped >= 1).all()
+    # PK should be unique on (ticker, end, filed)
+    assert not panel.duplicated(
+        subset=['ticker', 'end', 'filed']).any()
+
+  def test_has_price_and_market_cap(self, tmp_path):
+    from data.gold.backtest.panel import \
+        BacktestPanelBuilder  # pylint: disable=import-outside-toplevel
+    builder = BacktestPanelBuilder(
+        silver_dir=SILVER_DIR, gold_dir=tmp_path)
+    panel = builder.build()
+
+    assert 'price' in panel.columns
+    assert 'market_cap' in panel.columns
+    # At least some rows should have price data
+    assert panel['price'].notna().any()

--- a/data/gold/transforms_test.py
+++ b/data/gold/transforms_test.py
@@ -1,0 +1,138 @@
+"""Tests for Gold transforms — public interface only."""
+
+import pandas as pd
+import pytest
+
+from data.gold.transforms import calculate_market_cap
+from data.gold.transforms import join_metrics_by_cfo_filed
+from data.gold.transforms import join_prices_pit
+
+
+def _make_metrics_q(rows: list[dict]) -> pd.DataFrame:
+  """Build a long-format metrics DataFrame for testing."""
+  return pd.DataFrame(rows)
+
+
+class TestJoinMetricsByCFOFiled:
+  """join_metrics_by_cfo_filed() public interface tests."""
+
+  def test_joins_cfo_capex_shares_by_end_date(self):
+    """All three metrics joined on same end date."""
+    metrics = _make_metrics_q([
+        {'cik10': 'AAPL', 'metric': 'CFO', 'end': '2024-03-31',
+         'filed': '2024-05-01', 'q_val': 100.0, 'ttm_val': 400.0,
+         'fiscal_year': 2024, 'fiscal_quarter': 'Q1'},
+        {'cik10': 'AAPL', 'metric': 'CAPEX', 'end': '2024-03-31',
+         'filed': '2024-05-01', 'q_val': 20.0, 'ttm_val': 80.0,
+         'fiscal_year': 2024, 'fiscal_quarter': 'Q1'},
+        {'cik10': 'AAPL', 'metric': 'SHARES', 'end': '2024-03-31',
+         'filed': '2024-05-01', 'q_val': 1_000_000.0, 'ttm_val': None,
+         'fiscal_year': 2024, 'fiscal_quarter': 'Q1'},
+    ])
+    result = join_metrics_by_cfo_filed(metrics)
+
+    assert len(result) == 1
+    row = result.iloc[0]
+    assert row['cfo_q'] == 100.0
+    assert row['cfo_ttm'] == 400.0
+    assert row['capex_q'] == 20.0
+    assert row['shares_q'] == 1_000_000.0
+
+  def test_missing_capex_does_not_crash(self):
+    """When CAPEX is missing, join still succeeds with CFO and SHARES."""
+    metrics = _make_metrics_q([
+        {'cik10': 'AAPL', 'metric': 'CFO', 'end': '2024-03-31',
+         'filed': '2024-05-01', 'q_val': 100.0, 'ttm_val': 400.0,
+         'fiscal_year': 2024, 'fiscal_quarter': 'Q1'},
+        {'cik10': 'AAPL', 'metric': 'SHARES', 'end': '2024-03-31',
+         'filed': '2024-05-01', 'q_val': 1_000_000.0, 'ttm_val': None,
+         'fiscal_year': 2024, 'fiscal_quarter': 'Q1'},
+    ])
+    result = join_metrics_by_cfo_filed(metrics)
+
+    assert len(result) == 1
+    assert result.iloc[0]['cfo_q'] == 100.0
+    assert result.iloc[0]['shares_q'] == 1_000_000.0
+
+  def test_no_cfo_returns_empty(self):
+    """When there is no CFO data, result is empty."""
+    metrics = _make_metrics_q([
+        {'cik10': 'AAPL', 'metric': 'CAPEX', 'end': '2024-03-31',
+         'filed': '2024-05-01', 'q_val': 20.0, 'ttm_val': 80.0,
+         'fiscal_year': 2024, 'fiscal_quarter': 'Q1'},
+    ])
+    result = join_metrics_by_cfo_filed(metrics)
+    assert result.empty
+
+  def test_pit_uses_most_recent_capex_before_cfo_filed(self):
+    """CAPEX filed before CFO is used; later filings are excluded."""
+    metrics = _make_metrics_q([
+        {'cik10': 'AAPL', 'metric': 'CFO', 'end': '2024-03-31',
+         'filed': '2024-05-15', 'q_val': 100.0, 'ttm_val': 400.0,
+         'fiscal_year': 2024, 'fiscal_quarter': 'Q1'},
+        # CAPEX filed before CFO
+        {'cik10': 'AAPL', 'metric': 'CAPEX', 'end': '2024-03-31',
+         'filed': '2024-05-10', 'q_val': 20.0, 'ttm_val': 80.0,
+         'fiscal_year': 2024, 'fiscal_quarter': 'Q1'},
+    ])
+    result = join_metrics_by_cfo_filed(metrics)
+
+    assert len(result) == 1
+    assert result.iloc[0]['capex_q'] == 20.0
+
+
+class TestJoinPricesPIT:
+  """join_prices_pit() public interface tests."""
+
+  def test_joins_first_price_after_filed(self):
+    """Price from the first trading day after filed date."""
+    metrics = pd.DataFrame([{
+        'ticker': 'AAPL', 'end': '2024-03-31',
+        'filed': '2024-05-01', 'cfo_q': 100.0,
+    }])
+    prices = pd.DataFrame([
+        {'symbol': 'AAPL.US', 'date': '2024-04-30', 'close': 170.0},
+        {'symbol': 'AAPL.US', 'date': '2024-05-01', 'close': 172.0},
+        {'symbol': 'AAPL.US', 'date': '2024-05-02', 'close': 175.0},
+    ])
+    result = join_prices_pit(metrics, prices)
+
+    assert len(result) == 1
+    assert result.iloc[0]['price'] == 172.0
+
+  def test_no_price_for_ticker_excluded(self):
+    """Tickers with no price data are excluded from output."""
+    metrics = pd.DataFrame([{
+        'ticker': 'AAPL', 'end': '2024-03-31',
+        'filed': '2024-05-01', 'cfo_q': 100.0,
+    }])
+    prices = pd.DataFrame([
+        {'symbol': 'MSFT.US', 'date': '2024-05-01', 'close': 400.0},
+    ])
+    result = join_prices_pit(metrics, prices)
+    assert result.empty
+
+
+class TestCalculateMarketCap:
+  """calculate_market_cap() public interface tests."""
+
+  def test_market_cap_is_shares_times_price(self):
+    panel = pd.DataFrame([{
+        'shares_q': 1_000_000.0,
+        'price': 150.0,
+    }])
+    result = calculate_market_cap(panel)
+    assert result.iloc[0]['market_cap'] == pytest.approx(150_000_000.0)
+
+  def test_missing_columns_returns_none(self):
+    """Missing shares or price columns → market_cap is None."""
+    panel = pd.DataFrame([{'ticker': 'AAPL'}])
+    result = calculate_market_cap(panel)
+    assert result.iloc[0]['market_cap'] is None
+
+  def test_does_not_mutate_input(self):
+    """Original DataFrame is not modified."""
+    panel = pd.DataFrame([{'shares_q': 1_000_000.0, 'price': 150.0}])
+    original_cols = list(panel.columns)
+    calculate_market_cap(panel)
+    assert list(panel.columns) == original_cols

--- a/data/silver/build.py
+++ b/data/silver/build.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Any
 
 from data.silver.core.pipeline import PipelineContext
+from data.silver.sources.dart.pipeline import DARTPipeline
+from data.silver.sources.krx.pipeline import KRXPipeline
 from data.silver.sources.sec.pipeline import SECPipeline
 from data.silver.sources.stooq.pipeline import StooqPipeline
 
@@ -26,20 +28,11 @@ MARKET_SOURCES: dict[str, dict[str, type]] = {
         'sec': SECPipeline,
         'stooq': StooqPipeline,
     },
-    'kr': {},  # KRX pipeline is standalone (not Pipeline subclass)
+    'kr': {
+        'dart': DARTPipeline,
+        'krx': KRXPipeline,
+    },
 }
-
-
-def _build_krx(bronze_dir: Path, silver_dir: Path) -> bool:
-  """Build KRX Silver prices (standalone, not Pipeline-based)."""
-  from data.silver.sources.krx.pipeline import \
-      build_krx_prices  # pylint: disable=import-outside-toplevel
-  try:
-    build_krx_prices(bronze_dir, silver_dir)
-    return True
-  except (FileNotFoundError, ValueError) as exc:
-    logger.error('KRX failed: %s', exc)
-    return False
 
 
 def main() -> None:
@@ -72,19 +65,11 @@ def main() -> None:
     for name, cls in srcs.items():
       pipeline_classes[name] = cls
 
-  # Run Pipeline-based sources.
+  # Run all pipelines.
   results: dict[str, Any] = {}
   for name, cls in pipeline_classes.items():
     logger.info('Running %s pipeline...', name)
     results[name] = cls(context).run()
-
-  # Run KRX (standalone).
-  if 'kr' in args.markets:
-    logger.info('Running krx pipeline...')
-    krx_ok = _build_krx(args.bronze_dir, args.silver_dir)
-    results['krx'] = type(
-        'Result', (), {'success': krx_ok, 'errors': [],
-                        'datasets': {}})()
 
   # Summary.
   success_count = sum(

--- a/data/silver/sources/dart/pipeline.py
+++ b/data/silver/sources/dart/pipeline.py
@@ -38,9 +38,15 @@ class DARTPipeline(Pipeline):
     else:
       facts = shares
 
+    # Fill SHARES end/filed from actual fact dates per stock.
+    if not facts.empty:
+      shares_mask = (
+          (facts['metric'] == 'SHARES') & facts['end'].isna())
+      if shares_mask.any():
+        facts = self._fill_shares_dates(facts, shares_mask)
+
     self.datasets['facts_long'] = facts
     self.datasets['companies'] = self._build_companies(facts)
-    self._corp_to_stock = corp_to_stock
 
   def transform(self) -> None:
     # Extraction already produces the target schema.
@@ -203,6 +209,34 @@ class DARTPipeline(Pipeline):
           'tag': 'shares',
       })
     return pd.DataFrame(rows)
+
+  @staticmethod
+  def _fill_shares_dates(
+      facts: pd.DataFrame,
+      shares_mask: pd.Series,
+  ) -> pd.DataFrame:
+    """Fill NaT end/filed on SHARES rows from other facts."""
+    non_shares = facts[~shares_mask & facts['end'].notna()]
+    result_parts = [facts[~shares_mask].copy()]
+
+    for cik10, share_rows in facts[shares_mask].groupby('cik10'):
+      cik_facts = non_shares[non_shares['cik10'] == cik10]
+      if cik_facts.empty:
+        continue
+      ends = cik_facts[['end', 'filed', 'fiscal_year',
+                         'fiscal_quarter', 'fy',
+                         'fp']].drop_duplicates()
+      for _, end_row in ends.iterrows():
+        expanded = share_rows.copy()
+        expanded['end'] = end_row['end']
+        expanded['filed'] = end_row['filed']
+        expanded['fiscal_year'] = end_row['fiscal_year']
+        expanded['fiscal_quarter'] = end_row['fiscal_quarter']
+        expanded['fy'] = end_row['fy']
+        expanded['fp'] = end_row['fp']
+        result_parts.append(expanded)
+
+    return pd.concat(result_parts, ignore_index=True)
 
   @staticmethod
   def _build_companies(facts: pd.DataFrame) -> pd.DataFrame:

--- a/data/silver/sources/dart/pipeline.py
+++ b/data/silver/sources/dart/pipeline.py
@@ -1,0 +1,215 @@
+"""DART Silver pipeline — Bronze JSON to Silver parquet."""
+
+import json
+import logging
+from pathlib import Path
+import re
+from xml.etree import ElementTree
+
+import pandas as pd
+
+from data.silver.core.pipeline import Pipeline
+from data.silver.sources.dart.extractors import DARTExtractor
+
+logger = logging.getLogger(__name__)
+
+_QTR_MONTH = {'Q1': '03-31', 'Q2': '06-30', 'Q3': '09-30', 'Q4': '12-31'}
+
+
+class DARTPipeline(Pipeline):
+  """DART financial statements and shares → Silver facts_long + companies."""
+
+  def extract(self) -> None:
+    dart_dir = self.context.bronze_dir / 'dart'
+    if not dart_dir.exists():
+      logger.info('No DART Bronze dir, producing empty output')
+      self.datasets['facts_long'] = pd.DataFrame()
+      self.datasets['companies'] = pd.DataFrame()
+      return
+
+    corp_to_stock = self._load_corp_mapping(dart_dir)
+    facts = self._extract_facts(dart_dir, corp_to_stock)
+    shares = self._extract_shares(dart_dir, corp_to_stock)
+
+    if not facts.empty and not shares.empty:
+      facts = pd.concat([facts, shares], ignore_index=True)
+    elif shares.empty:
+      pass  # facts only
+    else:
+      facts = shares
+
+    self.datasets['facts_long'] = facts
+    self.datasets['companies'] = self._build_companies(facts)
+    self._corp_to_stock = corp_to_stock
+
+  def transform(self) -> None:
+    # Extraction already produces the target schema.
+    pass
+
+  def validate(self) -> None:
+    facts = self.datasets.get('facts_long', pd.DataFrame())
+    if facts.empty:
+      return
+    required = [
+        'cik10', 'metric', 'val', 'end', 'filed',
+        'fy', 'fp', 'fiscal_year', 'fiscal_quarter', 'tag',
+    ]
+    missing = [c for c in required if c not in facts.columns]
+    if missing:
+      self.errors.append(f'Missing columns in facts_long: {missing}')
+
+  def load(self) -> None:
+    out_dir = self.context.silver_dir / 'dart'
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    facts = self.datasets.get('facts_long', pd.DataFrame())
+    if not facts.empty:
+      facts.to_parquet(out_dir / 'facts_long.parquet', index=False)
+      logger.info('DART facts_long: %d rows', len(facts))
+
+    companies = self.datasets.get('companies', pd.DataFrame())
+    if not companies.empty:
+      companies.to_parquet(out_dir / 'companies.parquet', index=False)
+      logger.info('DART companies: %d rows', len(companies))
+
+  # -- Private helpers --
+
+  @staticmethod
+  def _load_corp_mapping(dart_dir: Path) -> dict[str, str]:
+    """Load corp_code → stock_code mapping from CORPCODE.xml."""
+    xml_path = dart_dir / 'CORPCODE.xml'
+    if not xml_path.exists():
+      return {}
+
+    tree = ElementTree.parse(xml_path)  # noqa: S314
+    root = tree.getroot()
+    result: dict[str, str] = {}
+    for item in root.findall('list'):
+      corp_el = item.find('corp_code')
+      stock_el = item.find('stock_code')
+      if (corp_el is not None and stock_el is not None
+          and corp_el.text and stock_el.text
+          and stock_el.text.strip()):
+        result[corp_el.text.strip()] = stock_el.text.strip()
+    return result
+
+  @staticmethod
+  def _extract_facts(
+      dart_dir: Path,
+      corp_to_stock: dict[str, str],
+  ) -> pd.DataFrame:
+    """Extract DART finstate JSONs into facts DataFrame."""
+    finstate_dir = dart_dir / 'finstate'
+    if not finstate_dir.exists():
+      return pd.DataFrame()
+
+    extractor = DARTExtractor()
+    parts: list[pd.DataFrame] = []
+
+    for path in sorted(finstate_dir.glob('*.json')):
+      if path.name.endswith('.meta.json'):
+        continue
+
+      df = extractor.extract_facts(path)
+      if df.empty:
+        continue
+
+      mapped = df[df['metric'].notna()].copy()
+      if mapped.empty:
+        continue
+
+      # Map corp_code → stock_code as cik10.
+      mapped['cik10'] = mapped['corp_code'].map(
+          corp_to_stock).fillna(mapped['corp_code'])
+      mapped = mapped.rename(columns={'bsns_year': 'fy'})
+      mapped['fiscal_year'] = pd.to_numeric(
+          mapped['fy'], errors='coerce')
+
+      # Quarter detection from filename.
+      qtr = mapped['quarter'].iloc[0] if (
+          'quarter' in mapped.columns
+          and mapped['quarter'].notna().any()
+      ) else 'Q4'
+      mapped['fiscal_quarter'] = qtr
+      mapped['fp'] = 'FY' if qtr == 'Q4' else qtr
+
+      # tag column (required by aggregation.py).
+      mapped['tag'] = mapped['account_nm']
+
+      # End date from (fy, quarter).
+      mm_dd = _QTR_MONTH.get(qtr, '12-31')
+      fy_strs = mapped['fy'].astype(str)
+      end_str = fy_strs + f'-{mm_dd}'  # type: ignore[operator]
+      mapped['end'] = pd.to_datetime(end_str)
+
+      # Approximate filed date.
+      filed_lag = 90 if qtr == 'Q4' else 45
+      mapped['filed'] = mapped['end'] + pd.Timedelta(days=filed_lag)
+
+      parts.append(mapped)
+
+    if not parts:
+      return pd.DataFrame()
+    return pd.concat(parts, ignore_index=True)
+
+  @staticmethod
+  def _extract_shares(
+      dart_dir: Path,
+      corp_to_stock: dict[str, str],
+  ) -> pd.DataFrame:
+    """Extract shares outstanding from DART shares JSONs."""
+    shares_dir = dart_dir / 'shares'
+    if not shares_dir.exists():
+      return pd.DataFrame()
+
+    shares_map: dict[str, float] = {}
+    for path in shares_dir.glob('*.json'):
+      if path.name.endswith('.meta.json'):
+        continue
+      try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+        if data.get('status') != '000' or not data.get('list'):
+          continue
+        corp_code = path.stem
+        stock_code = corp_to_stock.get(corp_code, corp_code)
+        for item in data['list']:
+          se = item.get('se', '')
+          if se.strip() in ('보통주',):
+            raw = item.get('istc_totqy', '')
+            cleaned = re.sub(r'[,\s]', '', str(raw))
+            if cleaned and cleaned != '-':
+              shares_map[stock_code] = float(cleaned)
+              break
+      except (json.JSONDecodeError, OSError, ValueError):
+        continue
+
+    if not shares_map:
+      return pd.DataFrame()
+
+    # Build SHARES facts rows — one per stock code.
+    # Use a nominal end/filed for now; Gold will fill across quarters.
+    rows: list[dict] = []
+    for stock_code, val in shares_map.items():
+      rows.append({
+          'cik10': stock_code,
+          'metric': 'SHARES',
+          'val': val,
+          'end': pd.NaT,
+          'filed': pd.NaT,
+          'fy': '',
+          'fp': 'FY',
+          'fiscal_year': None,
+          'fiscal_quarter': 'Q4',
+          'tag': 'shares',
+      })
+    return pd.DataFrame(rows)
+
+  @staticmethod
+  def _build_companies(facts: pd.DataFrame) -> pd.DataFrame:
+    """Build companies lookup from facts."""
+    if facts.empty:
+      return pd.DataFrame(columns=['cik10', 'ticker'])
+
+    companies = facts[['cik10']].drop_duplicates().copy()
+    companies['ticker'] = companies['cik10']
+    return companies.reset_index(drop=True)

--- a/data/silver/sources/dart/tests/pipeline_test.py
+++ b/data/silver/sources/dart/tests/pipeline_test.py
@@ -1,0 +1,234 @@
+"""Tests for DART Silver pipeline — public interface only."""
+
+import json
+
+import pandas as pd
+import pytest
+
+from data.silver.core.pipeline import PipelineContext
+
+# Minimal synthetic Bronze data for testing.
+CORP_XML = '''<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <list>
+    <corp_code>00126380</corp_code>
+    <corp_name>삼성전자</corp_name>
+    <stock_code>005930</stock_code>
+    <modify_date>20240101</modify_date>
+  </list>
+  <list>
+    <corp_code>00164779</corp_code>
+    <corp_name>SK하이닉스</corp_name>
+    <stock_code>000660</stock_code>
+    <modify_date>20240101</modify_date>
+  </list>
+</result>'''
+
+FINSTATE_Q1 = {
+    'status': '000',
+    'list': [
+        {
+            'sj_div': 'CF',
+            'account_nm': '영업활동현금흐름',
+            'thstrm_amount': '10,000,000',
+            'bsns_year': '2024',
+            'reprt_code': '11013',
+            'corp_code': '00126380',
+        },
+        {
+            'sj_div': 'IS',
+            'account_nm': '매출액',
+            'thstrm_amount': '50,000,000',
+            'bsns_year': '2024',
+            'reprt_code': '11013',
+            'corp_code': '00126380',
+        },
+        {
+            'sj_div': 'BS',
+            'account_nm': '자산총계',
+            'thstrm_amount': '500,000,000',
+            'bsns_year': '2024',
+            'reprt_code': '11013',
+            'corp_code': '00126380',
+        },
+    ],
+}
+
+FINSTATE_FY = {
+    'status': '000',
+    'list': [
+        {
+            'sj_div': 'CF',
+            'account_nm': '영업활동현금흐름',
+            'thstrm_amount': '40,000,000',
+            'bsns_year': '2024',
+            'reprt_code': '11011',
+            'corp_code': '00126380',
+        },
+    ],
+}
+
+SHARES_DATA = {
+    'status': '000',
+    'list': [
+        {
+            'se': '보통주',
+            'istc_totqy': '5,969,782,550',
+            'corp_code': '00126380',
+        },
+    ],
+}
+
+
+@pytest.fixture(name='bronze_dir')
+def make_bronze(tmp_path):
+  """Create synthetic DART Bronze structure."""
+  dart_dir = tmp_path / 'dart'
+
+  # CORPCODE.xml
+  dart_dir.mkdir(parents=True)
+  (dart_dir / 'CORPCODE.xml').write_text(CORP_XML, encoding='utf-8')
+
+  # Finstate JSONs
+  finstate_dir = dart_dir / 'finstate'
+  finstate_dir.mkdir()
+  (finstate_dir / '00126380_2024_Q1.json').write_text(
+      json.dumps(FINSTATE_Q1, ensure_ascii=False), encoding='utf-8')
+  (finstate_dir / '00126380_2024.json').write_text(
+      json.dumps(FINSTATE_FY, ensure_ascii=False), encoding='utf-8')
+
+  # Shares JSONs
+  shares_dir = dart_dir / 'shares'
+  shares_dir.mkdir()
+  (shares_dir / '00126380.json').write_text(
+      json.dumps(SHARES_DATA, ensure_ascii=False), encoding='utf-8')
+
+  return tmp_path
+
+
+class TestDARTPipeline:
+
+  def test_run_produces_successful_result(self, bronze_dir, tmp_path):
+    from data.silver.sources.dart.pipeline import \
+        DARTPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
+    result = DARTPipeline(ctx).run()
+
+    assert result.success
+    assert not result.errors
+
+  def test_produces_facts_long_parquet(self, bronze_dir, tmp_path):
+    from data.silver.sources.dart.pipeline import \
+        DARTPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
+    DARTPipeline(ctx).run()
+
+    path = tmp_path / 'dart' / 'facts_long.parquet'
+    assert path.exists()
+
+    df = pd.read_parquet(path)
+    assert not df.empty
+
+  def test_facts_long_has_required_schema(self, bronze_dir, tmp_path):
+    """Output must match SEC facts_long schema for Gold compatibility."""
+    from data.silver.sources.dart.pipeline import \
+        DARTPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
+    DARTPipeline(ctx).run()
+
+    df = pd.read_parquet(tmp_path / 'dart' / 'facts_long.parquet')
+    required = [
+        'cik10', 'metric', 'val', 'end', 'filed',
+        'fy', 'fp', 'fiscal_year', 'fiscal_quarter', 'tag',
+    ]
+    for col in required:
+      assert col in df.columns, f'Missing column: {col}'
+
+  def test_corp_code_mapped_to_stock_code(self, bronze_dir, tmp_path):
+    """cik10 should be stock_code (005930), not corp_code (00126380)."""
+    from data.silver.sources.dart.pipeline import \
+        DARTPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
+    DARTPipeline(ctx).run()
+
+    df = pd.read_parquet(tmp_path / 'dart' / 'facts_long.parquet')
+    assert '005930' in df['cik10'].values
+    assert '00126380' not in df['cik10'].values
+
+  def test_quarter_detection_from_filename(self, bronze_dir, tmp_path):
+    """Q1 file → fiscal_quarter='Q1', FY file → fiscal_quarter='Q4'."""
+    from data.silver.sources.dart.pipeline import \
+        DARTPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
+    DARTPipeline(ctx).run()
+
+    df = pd.read_parquet(tmp_path / 'dart' / 'facts_long.parquet')
+    quarters = set(df['fiscal_quarter'].unique())
+    assert 'Q1' in quarters
+    assert 'Q4' in quarters
+
+  def test_end_date_constructed_from_fy_and_quarter(
+      self, bronze_dir, tmp_path):
+    from data.silver.sources.dart.pipeline import \
+        DARTPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
+    DARTPipeline(ctx).run()
+
+    df = pd.read_parquet(tmp_path / 'dart' / 'facts_long.parquet')
+    q1_rows = df[df['fiscal_quarter'] == 'Q1']
+    assert not q1_rows.empty
+    # Q1 2024 → end = 2024-03-31
+    assert q1_rows.iloc[0]['end'] == pd.Timestamp('2024-03-31')
+
+  def test_filed_date_estimated(self, bronze_dir, tmp_path):
+    """Filed = end + 45d (Q1-Q3) or end + 90d (Q4)."""
+    from data.silver.sources.dart.pipeline import \
+        DARTPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
+    DARTPipeline(ctx).run()
+
+    df = pd.read_parquet(tmp_path / 'dart' / 'facts_long.parquet')
+    q1 = df[df['fiscal_quarter'] == 'Q1'].iloc[0]
+    q4 = df[df['fiscal_quarter'] == 'Q4'].iloc[0]
+
+    assert q1['filed'] == pd.Timestamp('2024-03-31') + pd.Timedelta(days=45)
+    assert q4['filed'] == pd.Timestamp('2024-12-31') + pd.Timedelta(days=90)
+
+  def test_shares_integrated_into_facts(self, bronze_dir, tmp_path):
+    """SHARES metric rows added from shares API data."""
+    from data.silver.sources.dart.pipeline import \
+        DARTPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
+    DARTPipeline(ctx).run()
+
+    df = pd.read_parquet(tmp_path / 'dart' / 'facts_long.parquet')
+    shares = df[df['metric'] == 'SHARES']
+    assert not shares.empty
+    assert shares.iloc[0]['val'] == pytest.approx(5_969_782_550.0)
+
+  def test_produces_companies_parquet(self, bronze_dir, tmp_path):
+    from data.silver.sources.dart.pipeline import \
+        DARTPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
+    DARTPipeline(ctx).run()
+
+    path = tmp_path / 'dart' / 'companies.parquet'
+    assert path.exists()
+
+    df = pd.read_parquet(path)
+    assert 'cik10' in df.columns
+    assert 'ticker' in df.columns
+    assert '005930' in df['ticker'].values
+
+  def test_empty_bronze_produces_empty_result(self, tmp_path):
+    """No DART data → pipeline succeeds with empty datasets."""
+    from data.silver.sources.dart.pipeline import \
+        DARTPipeline  # pylint: disable=import-outside-toplevel
+    bronze = tmp_path / 'bronze'
+    bronze.mkdir()
+    silver = tmp_path / 'silver'
+    silver.mkdir()
+    ctx = PipelineContext(bronze_dir=bronze, silver_dir=silver)
+    result = DARTPipeline(ctx).run()
+
+    assert result.success

--- a/data/silver/sources/dart/tests/pipeline_test.py
+++ b/data/silver/sources/dart/tests/pipeline_test.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from data.silver.core.pipeline import PipelineContext
+from data.silver.sources.dart.pipeline import DARTPipeline
 
 # Minimal synthetic Bronze data for testing.
 CORP_XML = '''<?xml version="1.0" encoding="UTF-8"?>
@@ -109,8 +110,6 @@ def make_bronze(tmp_path):
 class TestDARTPipeline:
 
   def test_run_produces_successful_result(self, bronze_dir, tmp_path):
-    from data.silver.sources.dart.pipeline import \
-        DARTPipeline  # pylint: disable=import-outside-toplevel
     ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
     result = DARTPipeline(ctx).run()
 
@@ -118,8 +117,6 @@ class TestDARTPipeline:
     assert not result.errors
 
   def test_produces_facts_long_parquet(self, bronze_dir, tmp_path):
-    from data.silver.sources.dart.pipeline import \
-        DARTPipeline  # pylint: disable=import-outside-toplevel
     ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
     DARTPipeline(ctx).run()
 
@@ -131,8 +128,6 @@ class TestDARTPipeline:
 
   def test_facts_long_has_required_schema(self, bronze_dir, tmp_path):
     """Output must match SEC facts_long schema for Gold compatibility."""
-    from data.silver.sources.dart.pipeline import \
-        DARTPipeline  # pylint: disable=import-outside-toplevel
     ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
     DARTPipeline(ctx).run()
 
@@ -146,8 +141,6 @@ class TestDARTPipeline:
 
   def test_corp_code_mapped_to_stock_code(self, bronze_dir, tmp_path):
     """cik10 should be stock_code (005930), not corp_code (00126380)."""
-    from data.silver.sources.dart.pipeline import \
-        DARTPipeline  # pylint: disable=import-outside-toplevel
     ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
     DARTPipeline(ctx).run()
 
@@ -157,8 +150,6 @@ class TestDARTPipeline:
 
   def test_quarter_detection_from_filename(self, bronze_dir, tmp_path):
     """Q1 file → fiscal_quarter='Q1', FY file → fiscal_quarter='Q4'."""
-    from data.silver.sources.dart.pipeline import \
-        DARTPipeline  # pylint: disable=import-outside-toplevel
     ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
     DARTPipeline(ctx).run()
 
@@ -169,8 +160,6 @@ class TestDARTPipeline:
 
   def test_end_date_constructed_from_fy_and_quarter(
       self, bronze_dir, tmp_path):
-    from data.silver.sources.dart.pipeline import \
-        DARTPipeline  # pylint: disable=import-outside-toplevel
     ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
     DARTPipeline(ctx).run()
 
@@ -182,8 +171,6 @@ class TestDARTPipeline:
 
   def test_filed_date_estimated(self, bronze_dir, tmp_path):
     """Filed = end + 45d (Q1-Q3) or end + 90d (Q4)."""
-    from data.silver.sources.dart.pipeline import \
-        DARTPipeline  # pylint: disable=import-outside-toplevel
     ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
     DARTPipeline(ctx).run()
 
@@ -196,8 +183,6 @@ class TestDARTPipeline:
 
   def test_shares_integrated_into_facts(self, bronze_dir, tmp_path):
     """SHARES metric rows added from shares API data."""
-    from data.silver.sources.dart.pipeline import \
-        DARTPipeline  # pylint: disable=import-outside-toplevel
     ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
     DARTPipeline(ctx).run()
 
@@ -206,9 +191,19 @@ class TestDARTPipeline:
     assert not shares.empty
     assert shares.iloc[0]['val'] == pytest.approx(5_969_782_550.0)
 
+  def test_shares_have_valid_end_and_filed(
+      self, bronze_dir, tmp_path):
+    """SHARES rows must have real end/filed dates, not NaT."""
+    ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
+    DARTPipeline(ctx).run()
+
+    df = pd.read_parquet(tmp_path / 'dart' / 'facts_long.parquet')
+    shares = df[df['metric'] == 'SHARES']
+    assert not shares.empty
+    assert shares['end'].notna().all()
+    assert shares['filed'].notna().all()
+
   def test_produces_companies_parquet(self, bronze_dir, tmp_path):
-    from data.silver.sources.dart.pipeline import \
-        DARTPipeline  # pylint: disable=import-outside-toplevel
     ctx = PipelineContext(bronze_dir=bronze_dir, silver_dir=tmp_path)
     DARTPipeline(ctx).run()
 
@@ -222,8 +217,6 @@ class TestDARTPipeline:
 
   def test_empty_bronze_produces_empty_result(self, tmp_path):
     """No DART data → pipeline succeeds with empty datasets."""
-    from data.silver.sources.dart.pipeline import \
-        DARTPipeline  # pylint: disable=import-outside-toplevel
     bronze = tmp_path / 'bronze'
     bronze.mkdir()
     silver = tmp_path / 'silver'

--- a/data/silver/sources/krx/pipeline.py
+++ b/data/silver/sources/krx/pipeline.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from data.silver.core.pipeline import Pipeline
+
 logger = logging.getLogger(__name__)
 
 
@@ -74,6 +76,79 @@ def build_krx_prices(
       len(prices), prices['symbol'].nunique(), out_path)
 
   return out_path
+
+
+class KRXPipeline(Pipeline):
+  """KRX daily prices → Silver prices_daily.parquet."""
+
+  def extract(self) -> None:
+    krx_csv_dir = self.context.bronze_dir / 'krx' / 'daily'
+    if not krx_csv_dir.exists():
+      self.datasets['prices_daily'] = pd.DataFrame()
+      return
+
+    parts: list[pd.DataFrame] = []
+    for csv_path in sorted(krx_csv_dir.glob('*.csv')):
+      try:
+        df = pd.read_csv(csv_path, encoding='utf-8')
+        if df.empty:
+          continue
+
+        ticker = csv_path.stem
+        date_col = df.columns[0]
+
+        close_col = _find_column(df, ['close', '\uc885\uac00'])
+        vol_col = _find_column(df, ['volume', '\uac70\ub798\ub7c9'])
+        if close_col is None:
+          continue
+
+        out = pd.DataFrame({
+            'date': pd.to_datetime(df[date_col]),
+            'symbol': ticker,
+            'close': pd.to_numeric(df[close_col], errors='coerce'),
+        })
+        if vol_col is not None:
+          out['volume'] = pd.to_numeric(
+              df[vol_col], errors='coerce')
+        parts.append(out)
+      except Exception:  # pylint: disable=broad-except
+        logger.warning('Failed to read %s', csv_path.name)
+
+    if not parts:
+      self.datasets['prices_daily'] = pd.DataFrame()
+      return
+
+    prices = pd.concat(parts, ignore_index=True)
+    prices = prices.dropna(subset=['date', 'close'])
+    prices = prices.sort_values(
+        ['symbol', 'date']).reset_index(drop=True)
+    self.datasets['prices_daily'] = prices
+
+  def transform(self) -> None:
+    pass
+
+  def validate(self) -> None:
+    prices = self.datasets.get('prices_daily', pd.DataFrame())
+    if prices.empty:
+      return
+    required = ['date', 'symbol', 'close']
+    missing = [c for c in required if c not in prices.columns]
+    if missing:
+      self.errors.append(f'Missing columns: {missing}')
+
+  def load(self) -> None:
+    prices = self.datasets.get('prices_daily', pd.DataFrame())
+    if prices.empty:
+      return
+
+    out_dir = self.context.silver_dir / 'krx'
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / 'prices_daily.parquet'
+    prices.to_parquet(out_path, index=False)
+
+    logger.info(
+        'KRX Silver: %d rows, %d symbols -> %s',
+        len(prices), prices['symbol'].nunique(), out_path)
 
 
 def _find_column(

--- a/data/silver/sources/krx/pipeline.py
+++ b/data/silver/sources/krx/pipeline.py
@@ -112,7 +112,9 @@ class KRXPipeline(Pipeline):
               df[vol_col], errors='coerce')
         parts.append(out)
       except Exception:  # pylint: disable=broad-except
-        logger.warning('Failed to read %s', csv_path.name)
+        logger.warning(
+            'Failed to read %s', csv_path.name,
+            exc_info=True)
 
     if not parts:
       self.datasets['prices_daily'] = pd.DataFrame()

--- a/data/silver/sources/krx/tests/pipeline_test.py
+++ b/data/silver/sources/krx/tests/pipeline_test.py
@@ -5,12 +5,15 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from data.silver.core.pipeline import PipelineContext
+
 BRONZE_DIR = Path('data/bronze/out')
 HAS_KRX = (BRONZE_DIR / 'krx' / 'daily').exists()
 
 
 @pytest.mark.skipif(not HAS_KRX, reason='No KRX Bronze data')
 class TestKRXSilverPipeline:
+  """Tests for standalone build_krx_prices (legacy)."""
 
   def test_produces_prices_parquet(self, tmp_path):
     from data.silver.sources.krx.pipeline import \
@@ -46,3 +49,39 @@ class TestKRXSilverPipeline:
 
     df = pd.read_parquet(tmp_path / 'krx' / 'prices_daily.parquet')
     assert pd.api.types.is_datetime64_any_dtype(df['date'])
+
+
+@pytest.mark.skipif(not HAS_KRX, reason='No KRX Bronze data')
+class TestKRXPipeline:
+  """Tests for KRXPipeline(Pipeline) ABC implementation."""
+
+  def test_run_returns_successful_result(self, tmp_path):
+    from data.silver.sources.krx.pipeline import \
+        KRXPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=BRONZE_DIR, silver_dir=tmp_path)
+    result = KRXPipeline(ctx).run()
+
+    assert result.success
+    assert not result.errors
+
+  def test_produces_prices_daily_dataset(self, tmp_path):
+    from data.silver.sources.krx.pipeline import \
+        KRXPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=BRONZE_DIR, silver_dir=tmp_path)
+    result = KRXPipeline(ctx).run()
+
+    assert 'prices_daily' in result.datasets
+    df = result.datasets['prices_daily']
+    assert not df.empty
+    assert 'date' in df.columns
+    assert 'symbol' in df.columns
+    assert 'close' in df.columns
+
+  def test_writes_parquet_file(self, tmp_path):
+    from data.silver.sources.krx.pipeline import \
+        KRXPipeline  # pylint: disable=import-outside-toplevel
+    ctx = PipelineContext(bronze_dir=BRONZE_DIR, silver_dir=tmp_path)
+    KRXPipeline(ctx).run()
+
+    path = tmp_path / 'krx' / 'prices_daily.parquet'
+    assert path.exists()

--- a/screening/scorers/base.py
+++ b/screening/scorers/base.py
@@ -1,0 +1,14 @@
+"""Base class for screening scorers."""
+
+from abc import ABC
+from abc import abstractmethod
+
+import pandas as pd
+
+
+class Scorer(ABC):
+  """A scorer that assigns a 0-100 score to a stock candidate."""
+
+  @abstractmethod
+  def score(self, row: pd.Series) -> float:
+    """Return a score between 0 and 100."""

--- a/screening/scorers/fear.py
+++ b/screening/scorers/fear.py
@@ -3,9 +3,10 @@
 import pandas as pd
 
 from screening.scorers._utils import safe_float
+from screening.scorers.base import Scorer
 
 
-class FearScorer:
+class FearScorer(Scorer):
   """Score 0-100: higher = more fear/panic priced in."""
 
   def score(self, row: pd.Series) -> float:

--- a/screening/scorers/quality.py
+++ b/screening/scorers/quality.py
@@ -3,9 +3,10 @@
 import pandas as pd
 
 from screening.scorers._utils import safe_float
+from screening.scorers.base import Scorer
 
 
-class QualityScorer:
+class QualityScorer(Scorer):
   """Score 0-100: higher = stronger fundamentals."""
 
   def score(self, row: pd.Series) -> float:

--- a/screening/tests/scorers_test.py
+++ b/screening/tests/scorers_test.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 
+from screening.scorers.base import Scorer
 from screening.scorers.composite import CompositeScorer
 from screening.scorers.fear import FearScorer
 from screening.scorers.quality import QualityScorer
@@ -9,6 +10,19 @@ from screening.scorers.quality import QualityScorer
 
 def _make_series(**kwargs):
   return pd.Series(kwargs)
+
+
+class TestScorerInterface:
+
+  def test_fear_scorer_is_scorer(self):
+    assert isinstance(FearScorer(), Scorer)
+
+  def test_quality_scorer_is_scorer(self):
+    assert isinstance(QualityScorer(), Scorer)
+
+  def test_composite_is_not_row_scorer(self):
+    """CompositeScorer is a combiner, not a row-level Scorer."""
+    assert not isinstance(CompositeScorer(), Scorer)
 
 
 class TestFearScorer:


### PR DESCRIPTION
## Summary
- **Phase 5**: `Scorer(ABC)` 추가 — `FearScorer`, `QualityScorer`가 상속, `Filter(ABC)` 패턴과 일관성 확보
- **Phase 6**: Gold 레이어 테스트 보강 — `aggregation.py` (YTD→Q, TTM), `transforms.py` (PIT join, market cap), `BacktestPanelBuilder` 통합 테스트 (총 25개 신규)
- **Phase 1**: `DARTPipeline(Pipeline)` 생성 — Bronze DART JSON → Silver `facts_long.parquet` + `companies.parquet` (10개 테스트)
- **Phase 2**: `KRXPipeline(Pipeline)` 변환 — standalone 함수를 ABC 구현으로 표준화, `build.py` 특수 분기 제거

## Context
Gold 레이어가 Bronze를 직접 읽는 아키텍처 위반(3곳)을 해결하기 위한 기반 작업. 이 PR이 머지되면 Phase 3 (BasePanelBuilder 시장 무관화) → Phase 4 (Gold-Bronze 위반 제거)를 진행할 수 있음.

## Test plan
- [x] 162개 fast test 전체 pass
- [x] BacktestPanelBuilder 통합 테스트 3개 pass (Silver 데이터 필요)
- [x] pre-commit hooks (isort, pylint, yapf, mypy) 전부 pass
- [ ] `python -m data.silver.build --markets kr` 로 DART/KRX Silver 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)