### PR TITLE
refactor: remove Gold-to-Bronze layer violation via MarketSource

### DIFF
--- a/data/gold/backtest/panel.py
+++ b/data/gold/backtest/panel.py
@@ -26,35 +26,23 @@ class BacktestPanelBuilder(BasePanelBuilder):
       silver_dir: Path,
       gold_dir: Path,
       min_date: Optional[str] = None,
-      bronze_dir: Optional[Path] = None,
+      markets: Optional[list[str]] = None,
   ):
     super().__init__(
-        silver_dir, gold_dir, BACKTEST_PANEL_SCHEMA, min_date)
-    self._bronze_dir = bronze_dir
+        silver_dir, gold_dir, BACKTEST_PANEL_SCHEMA,
+        min_date, markets)
 
   def build(self) -> pd.DataFrame:
     """Build backtest panel with all PIT versions."""
     companies, facts, prices = self._load_data()
-
-    # Append Korean data if available.
-    if self._bronze_dir is not None:
-      kr_facts, kr_prices = ValuationPanelBuilder.load_kr_valuation_data(
-          self._bronze_dir)
-      if not kr_facts.empty:
-        facts['fy'] = facts['fy'].astype(str)
-        facts = pd.concat([facts, kr_facts], ignore_index=True)
-        kr_companies = kr_facts[['cik10']].drop_duplicates().copy()
-        kr_companies['ticker'] = kr_companies['cik10']
-        companies = pd.concat([companies, kr_companies], ignore_index=True)
-      if not kr_prices.empty:
-        prices = pd.concat([prices, kr_prices], ignore_index=True)
 
     metrics_q = self._build_quarterly_metrics(facts)
     metrics_wide = self._build_wide_metrics(metrics_q)
 
     # Merge additional metrics (revenue, ebit, balance sheet).
     builder = ValuationPanelBuilder(self.silver_dir, self.gold_dir)
-    metrics_wide = builder.merge_extra_metrics(metrics_q, metrics_wide)
+    metrics_wide = builder.merge_extra_metrics(
+        metrics_q, metrics_wide)
 
     metrics_wide = metrics_wide.merge(
         companies[['cik10', 'ticker']],

--- a/data/gold/build.py
+++ b/data/gold/build.py
@@ -30,7 +30,7 @@ def build_panels(
     panels: list[str],
     silver_dir: Path,
     gold_dir: Path,
-    bronze_dir: Path,
+    markets: list[str],
     min_date: str = '2010-01-01',
     validate: bool = True,
 ) -> None:
@@ -41,6 +41,7 @@ def build_panels(
     panels: List of panel names to build
     silver_dir: Path to Silver layer output
     gold_dir: Path to Gold layer output
+    markets: Markets to include (e.g., ['us', 'kr'])
     min_date: Minimum date filter
     validate: Whether to validate after build
   """
@@ -59,7 +60,7 @@ def build_panels(
         silver_dir=silver_dir,
         gold_dir=gold_dir,
         min_date=min_date,
-        bronze_dir=bronze_dir,
+        markets=markets,
     )
 
     panel = builder.build()
@@ -102,10 +103,11 @@ def main() -> None:
       help='Gold layer output directory',
   )
   parser.add_argument(
-      '--bronze-dir',
-      type=Path,
-      default=Path('data/bronze/out'),
-      help='Bronze layer directory (for DART facts)',
+      '--markets',
+      nargs='+',
+      choices=['us', 'kr'],
+      default=['us', 'kr'],
+      help='Markets to include (default: us kr)',
   )
   parser.add_argument(
       '--min-date',
@@ -124,7 +126,7 @@ def main() -> None:
       panels=args.panel,
       silver_dir=args.silver_dir,
       gold_dir=args.gold_dir,
-      bronze_dir=args.bronze_dir,
+      markets=args.markets,
       min_date=args.min_date,
       validate=not args.no_validate,
   )

--- a/data/gold/core/base.py
+++ b/data/gold/core/base.py
@@ -8,6 +8,7 @@ and produces a model-ready parquet panel.
 
 from abc import ABC
 from abc import abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -17,6 +18,38 @@ from data.gold.aggregation import build_quarterly_metrics
 from data.gold.config.schemas import PanelSchema
 from data.gold.transforms import join_metrics_by_cfo_filed
 from data.shared.io import ParquetWriter
+
+
+@dataclass
+class MarketSource:
+  """Pointer to Silver layer data for a single market."""
+  companies_path: Path
+  facts_path: Path
+  prices_path: Path
+
+
+def us_source(silver_dir: Path) -> MarketSource:
+  """US market source (SEC + Stooq)."""
+  return MarketSource(
+      companies_path=silver_dir / 'sec' / 'companies.parquet',
+      facts_path=silver_dir / 'sec' / 'facts_long.parquet',
+      prices_path=silver_dir / 'stooq' / 'prices_daily.parquet',
+  )
+
+
+def kr_source(silver_dir: Path) -> MarketSource:
+  """Korean market source (DART + KRX)."""
+  return MarketSource(
+      companies_path=silver_dir / 'dart' / 'companies.parquet',
+      facts_path=silver_dir / 'dart' / 'facts_long.parquet',
+      prices_path=silver_dir / 'krx' / 'prices_daily.parquet',
+  )
+
+
+MARKET_SOURCES = {
+    'us': us_source,
+    'kr': kr_source,
+}
 
 
 class BasePanelBuilder(ABC):
@@ -30,6 +63,7 @@ class BasePanelBuilder(ABC):
       gold_dir: Path,
       schema: PanelSchema,
       min_date: Optional[str] = None,
+      markets: Optional[list[str]] = None,
   ):
     self.silver_dir = Path(silver_dir)
     self.gold_dir = Path(gold_dir)
@@ -37,18 +71,49 @@ class BasePanelBuilder(ABC):
     self.min_date = min_date
     self.panel: Optional[pd.DataFrame] = None
 
+    if markets is None:
+      markets = ['us']
+    self._sources: list[MarketSource] = []
+    for market in markets:
+      factory = MARKET_SOURCES.get(market)
+      if factory:
+        src = factory(self.silver_dir)
+        if src.facts_path.exists():
+          self._sources.append(src)
+
   @abstractmethod
   def build(self) -> pd.DataFrame:
     """Build the panel. Subclasses must implement."""
 
-  def _load_data(self) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    """Load required data from Silver layer."""
-    companies = pd.read_parquet(
-        self.silver_dir / 'sec' / 'companies.parquet')
-    facts = pd.read_parquet(
-        self.silver_dir / 'sec' / 'facts_long.parquet')
-    prices = pd.read_parquet(
-        self.silver_dir / 'stooq' / 'prices_daily.parquet')
+  def _load_data(
+      self,
+  ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Load data from all configured market sources."""
+    companies_parts: list[pd.DataFrame] = []
+    facts_parts: list[pd.DataFrame] = []
+    prices_parts: list[pd.DataFrame] = []
+
+    for src in self._sources:
+      if src.companies_path.exists():
+        companies_parts.append(
+            pd.read_parquet(src.companies_path))
+      if src.facts_path.exists():
+        df = pd.read_parquet(src.facts_path)
+        # Normalize fy to string for cross-market concat.
+        if 'fy' in df.columns:
+          df['fy'] = df['fy'].astype(str)
+        facts_parts.append(df)
+      if src.prices_path.exists():
+        prices_parts.append(
+            pd.read_parquet(src.prices_path))
+
+    companies = (pd.concat(companies_parts, ignore_index=True)
+                 if companies_parts else pd.DataFrame())
+    facts = (pd.concat(facts_parts, ignore_index=True)
+             if facts_parts else pd.DataFrame())
+    prices = (pd.concat(prices_parts, ignore_index=True)
+              if prices_parts else pd.DataFrame())
+
     return companies, facts, prices
 
   def _build_quarterly_metrics(
@@ -77,15 +142,18 @@ class BasePanelBuilder(ABC):
     self.gold_dir.mkdir(parents=True, exist_ok=True)
     output_path = self.gold_dir / f'{self.schema.name}.parquet'
 
+    input_paths = []
+    for src in self._sources:
+      for p in [src.companies_path, src.facts_path,
+                src.prices_path]:
+        if p.exists():
+          input_paths.append(p)
+
     writer = ParquetWriter()
     writer.write(
         self.panel,
         output_path,
-        inputs=[
-            self.silver_dir / 'sec' / 'companies.parquet',
-            self.silver_dir / 'sec' / 'facts_long.parquet',
-            self.silver_dir / 'stooq' / 'prices_daily.parquet',
-        ],
+        inputs=input_paths,
         metadata={
             'layer': 'gold',
             'dataset': self.schema.name,

--- a/data/gold/core/base.py
+++ b/data/gold/core/base.py
@@ -73,6 +73,8 @@ class BasePanelBuilder(ABC):
 
     if markets is None:
       markets = ['us']
+    # Only include markets whose Silver data has been built.
+    # All panel builders require facts; skip if missing.
     self._sources: list[MarketSource] = []
     for market in markets:
       factory = MARKET_SOURCES.get(market)

--- a/data/gold/screening/panel.py
+++ b/data/gold/screening/panel.py
@@ -8,10 +8,8 @@ Unlike valuation/backtest panels (CFO-anchored, 3 metrics),
 this panel uses all available metrics and computes derived ratios.
 """
 
-import json
 import logging
 from pathlib import Path
-import re
 from typing import Optional
 
 import pandas as pd
@@ -22,38 +20,6 @@ from data.gold.transforms import calculate_market_cap
 from data.gold.transforms import join_prices_pit
 
 logger = logging.getLogger(__name__)
-
-
-def _load_kr_shares(
-    shares_dir: Path,
-    corp_to_stock: dict[str, str],
-) -> dict[str, float]:
-  """Load shares outstanding from DART shares JSON files.
-
-  Returns: {stock_code: shares_count}
-  """
-  result: dict[str, float] = {}
-  for path in shares_dir.glob('*.json'):
-    if path.name.endswith('.meta.json'):
-      continue
-    try:
-      data = json.loads(path.read_text(encoding='utf-8'))
-      if data.get('status') != '000' or not data.get('list'):
-        continue
-      corp_code = path.stem
-      stock_code = corp_to_stock.get(corp_code, corp_code)
-      for item in data['list']:
-        # '보통주' row has common shares outstanding
-        se = item.get('se', '')
-        if se.strip() in ('\ubcf4\ud1b5\uc8fc', '보통주'):
-          raw = item.get('istc_totqy', '')
-          cleaned = re.sub(r'[,\s]', '', str(raw))
-          if cleaned and cleaned != '-':
-            result[stock_code] = float(cleaned)
-            break
-    except (json.JSONDecodeError, OSError, ValueError):
-      continue
-  return result
 
 # Metrics we need for screening ratios.
 _TTM_METRICS = [
@@ -84,7 +50,7 @@ class ScreeningPanelBuilder(BasePanelBuilder):
       silver_dir: Path,
       gold_dir: Path,
       min_date: Optional[str] = None,
-      bronze_dir: Optional[Path] = None,
+      markets: Optional[list[str]] = None,
   ):
     schema = PanelSchema(
         name=_SCREENING_SCHEMA_NAME,
@@ -92,27 +58,12 @@ class ScreeningPanelBuilder(BasePanelBuilder):
         columns=[],
         primary_key=['ticker', 'end'],
     )
-    super().__init__(silver_dir, gold_dir, schema, min_date)
-    self._bronze_dir = bronze_dir
+    super().__init__(
+        silver_dir, gold_dir, schema, min_date, markets)
 
   def build(self) -> pd.DataFrame:
     """Build screening panel (US + optionally KR)."""
     companies, facts, prices = self._load_data()
-
-    # Append Korean data if bronze_dir has DART data.
-    if self._bronze_dir is not None:
-      kr_facts, kr_prices = self._load_kr_data(self._bronze_dir)
-      if not kr_facts.empty:
-        facts = pd.concat([facts, kr_facts], ignore_index=True)
-        # Add KR companies to the ticker map.
-        kr_companies = (
-            kr_facts[['cik10']].drop_duplicates().copy())
-        kr_companies['ticker'] = kr_companies['cik10']
-        companies = pd.concat(
-            [companies, kr_companies], ignore_index=True)
-        logger.info('Added %d Korean facts rows', len(kr_facts))
-      if not kr_prices.empty:
-        prices = pd.concat([prices, kr_prices], ignore_index=True)
 
     # Build quarterly + TTM for all metrics.
     metrics_q = self._build_quarterly_metrics(facts)
@@ -376,128 +327,3 @@ class ScreeningPanelBuilder(BasePanelBuilder):
       df['gp_margin'] = pd.NA
 
     return df
-
-  @staticmethod
-  def _load_kr_data(
-      bronze_dir: Path,
-  ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Load Korean DART facts + KRX prices from Bronze."""
-    from data.bronze.providers.dart import \
-        _parse_corp_codes  # pylint: disable=import-outside-toplevel
-    from data.silver.sources.dart.extractors import \
-        DARTExtractor  # pylint: disable=import-outside-toplevel
-
-    # Build corp_code -> stock_code mapping.
-    corp_xml = bronze_dir / 'dart' / 'CORPCODE.xml'
-    stock_to_corp: dict[str, str] = {}
-    corp_to_stock: dict[str, str] = {}
-    if corp_xml.exists():
-      stock_to_corp = _parse_corp_codes(corp_xml)
-      corp_to_stock = {v: k for k, v in stock_to_corp.items()}
-
-    # -- DART facts --
-    dart_dir = bronze_dir / 'dart' / 'finstate'
-    facts_list: list[pd.DataFrame] = []
-    if dart_dir.exists():
-      extractor = DARTExtractor()
-      for path in sorted(dart_dir.glob('*.json')):
-        if path.name.endswith('.meta.json'):
-          continue
-        df = extractor.extract_facts(path)
-        if not df.empty:
-          mapped = df[df['metric'].notna()].copy()
-          if not mapped.empty:
-            mapped['cik10'] = mapped['corp_code'].map(
-                corp_to_stock).fillna(mapped['corp_code'])
-            mapped = mapped.rename(columns={
-                'bsns_year': 'fy',
-            })
-            mapped['fiscal_year'] = pd.to_numeric(
-                mapped['fy'], errors='coerce')
-
-            # Quarter-aware end date and fiscal_quarter.
-            qtr = mapped['quarter'].iloc[0] if (
-                'quarter' in mapped.columns
-                and mapped['quarter'].notna().any()
-            ) else 'Q4'
-            mapped['fiscal_quarter'] = qtr
-            # fp must be 'FY' for Q4/annual so
-            # YTDToQuarterlyConverter handles it.
-            mapped['fp'] = 'FY' if qtr == 'Q4' else qtr
-
-            qtr_month = {
-                'Q1': '03-31', 'Q2': '06-30',
-                'Q3': '09-30', 'Q4': '12-31',
-            }
-            mm_dd = qtr_month.get(qtr, '12-31')
-            fy_strs = mapped['fy'].astype(str)
-            end_str = fy_strs + f'-{mm_dd}'  # type: ignore[operator]
-            mapped['end'] = pd.to_datetime(end_str)
-
-            # Approximate filed date: Q-end + 45 days
-            # (annual + 90 days).
-            filed_lag = 90 if qtr == 'Q4' else 45
-            mapped['filed'] = (
-                mapped['end']
-                + pd.Timedelta(days=filed_lag))
-
-            facts_list.append(mapped)
-
-    facts = (pd.concat(facts_list, ignore_index=True)
-             if facts_list else pd.DataFrame())
-
-    # -- DART shares outstanding --
-    shares_dir = bronze_dir / 'dart' / 'shares'
-    if shares_dir.exists() and not facts.empty:
-      shares_map = _load_kr_shares(shares_dir, corp_to_stock)
-      if shares_map:
-        shares_rows: list[dict] = []  # type: ignore[type-arg]
-        for stock_code, shares_val in shares_map.items():
-          # Add SHARES as a fact for each end date
-          ends = facts[facts['cik10'] == stock_code][
-              'end'].unique()
-          for end in ends:
-            shares_rows.append({
-                'cik10': stock_code,
-                'metric': 'SHARES',
-                'val': shares_val,
-                'end': end,
-                'filed': end + pd.Timedelta(days=90),
-                'fp': 'FY',
-                'fiscal_year': end.year,
-                'fiscal_quarter': 'Q4',
-                'fy': str(end.year),
-            })
-        if shares_rows:
-          shares_df = pd.DataFrame(shares_rows)
-          facts = pd.concat(
-              [facts, shares_df], ignore_index=True)
-
-    # -- KRX prices --
-    krx_dir = bronze_dir / 'krx' / 'daily'
-    price_list: list[pd.DataFrame] = []
-    if krx_dir.exists():
-      for csv_path in sorted(krx_dir.glob('*.csv')):
-        try:
-          pdf = pd.read_csv(csv_path, encoding='utf-8')
-          ticker = csv_path.stem
-          date_col = pdf.columns[0]
-          close_col = [c for c in pdf.columns
-                       if 'close' in c.lower()
-                       or '\uc885\uac00' in c]
-          if not close_col:
-            continue
-          out = pd.DataFrame({
-              'date': pd.to_datetime(pdf[date_col]),
-              'symbol': ticker,
-              'close': pd.to_numeric(
-                  pdf[close_col[0]], errors='coerce'),
-          })
-          price_list.append(out)
-        except Exception:  # pylint: disable=broad-except
-          continue
-
-    prices = (pd.concat(price_list, ignore_index=True)
-              if price_list else pd.DataFrame())
-
-    return facts, prices

--- a/data/gold/valuation/build.py
+++ b/data/gold/valuation/build.py
@@ -3,6 +3,7 @@ Build valuation panel.
 
 Usage:
   python -m data.gold.valuation.build
+  python -m data.gold.valuation.build --markets us kr
   python -m data.gold.valuation.build --no-validate
 """
 
@@ -26,8 +27,10 @@ def main() -> None:
       '--gold-dir', type=Path,
       default=Path('data/gold/out'))
   parser.add_argument(
-      '--bronze-dir', type=Path,
-      default=Path('data/bronze/out'))
+      '--markets', nargs='+',
+      choices=['us', 'kr'],
+      default=['us', 'kr'],
+      help='Markets to include (default: us kr)')
   parser.add_argument(
       '--min-date', type=str, default='2010-01-01')
   parser.add_argument(
@@ -38,7 +41,7 @@ def main() -> None:
       silver_dir=args.silver_dir,
       gold_dir=args.gold_dir,
       min_date=args.min_date,
-      bronze_dir=args.bronze_dir,
+      markets=args.markets,
   )
   builder.build()
 

--- a/data/gold/valuation/panel.py
+++ b/data/gold/valuation/panel.py
@@ -1,6 +1,6 @@
 """Valuation panel builder — latest version for current DCF.
 
-Supports both US (SEC) and Korean (DART) data.
+Supports both US (SEC) and Korean (DART) data via market sources.
 """
 
 import logging
@@ -37,41 +37,22 @@ class ValuationPanelBuilder(BasePanelBuilder):
       silver_dir: Path,
       gold_dir: Path,
       min_date: Optional[str] = None,
-      bronze_dir: Optional[Path] = None,
+      markets: Optional[list[str]] = None,
   ):
     super().__init__(
-        silver_dir, gold_dir, VALUATION_PANEL_SCHEMA, min_date)
-    self._bronze_dir = bronze_dir
+        silver_dir, gold_dir, VALUATION_PANEL_SCHEMA,
+        min_date, markets)
 
   def build(self) -> pd.DataFrame:
     """Build valuation panel with latest version per period."""
     companies, facts, prices = self._load_data()
 
-    # Append Korean data if available.
-    if self._bronze_dir is not None:
-      kr_facts, kr_prices = self.load_kr_valuation_data(
-          self._bronze_dir)
-      if not kr_facts.empty:
-        # Align fy type before concat to avoid PyArrow mixed type issues.
-        # KR DART data 'fy' is string, SEC US data 'fy' might be int/float.
-        facts['fy'] = facts['fy'].astype(str)
-        facts = pd.concat([facts, kr_facts], ignore_index=True)
-        kr_companies = (
-            kr_facts[['cik10']].drop_duplicates().copy())
-        kr_companies['ticker'] = kr_companies['cik10']
-        companies = pd.concat(
-            [companies, kr_companies], ignore_index=True)
-        logger.info(
-            'Added %d Korean facts rows', len(kr_facts))
-      if not kr_prices.empty:
-        prices = pd.concat(
-            [prices, kr_prices], ignore_index=True)
-
     metrics_q = self._build_quarterly_metrics(facts)
     metrics_wide = self._build_wide_metrics(metrics_q)
 
     # Merge additional metrics (revenue, ebit, balance sheet).
-    metrics_wide = self.merge_extra_metrics(metrics_q, metrics_wide)
+    metrics_wide = self.merge_extra_metrics(
+        metrics_q, metrics_wide)
 
     # Keep only latest filed version per (cik10, end)
     metrics_wide = metrics_wide.sort_values('filed')
@@ -142,150 +123,3 @@ class ValuationPanelBuilder(BasePanelBuilder):
           mdf, on=['cik10', 'end'], how='left')
 
     return metrics_wide
-
-  @staticmethod
-  def load_kr_valuation_data(bronze_dir: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Load Korean DART data for valuation (CFO, CAPEX, SHARES).
-
-    DART thstrm_amount is already per-quarter (not YTD), so
-    we mark all metrics as is_ytd=False to skip YTD->Q
-    conversion in build_quarterly_metrics.
-    """
-    from data.bronze.providers.dart import \
-        _parse_corp_codes  # pylint: disable=import-outside-toplevel
-    from data.silver.sources.dart.extractors import \
-        DARTExtractor  # pylint: disable=import-outside-toplevel
-
-    # Corp code mapping.
-    corp_xml = bronze_dir / 'dart' / 'CORPCODE.xml'
-    corp_to_stock: dict[str, str] = {}
-    if corp_xml.exists():
-      stock_to_corp = _parse_corp_codes(corp_xml)
-      corp_to_stock = {v: k for k, v in stock_to_corp.items()}
-
-    # Extract DART facts.
-    dart_dir = bronze_dir / 'dart' / 'finstate'
-    facts_list: list[pd.DataFrame] = []
-    if dart_dir.exists():
-      extractor = DARTExtractor()
-      for path in sorted(dart_dir.glob('*.json')):
-        if path.name.endswith('.meta.json'):
-          continue
-        df = extractor.extract_facts(path)
-        if df.empty:
-          continue
-        mapped = df[df['metric'].isin(
-            ['CFO', 'CAPEX', 'SHARES',
-             'REVENUE', 'EBIT', 'NET_INCOME',
-             'TOTAL_ASSETS', 'TOTAL_EQUITY',
-             'CURRENT_LIABILITIES', 'CASH'])].copy()
-        if mapped.empty:
-          continue
-
-        mapped['cik10'] = mapped['corp_code'].map(
-            corp_to_stock).fillna(mapped['corp_code'])
-        mapped = mapped.rename(columns={'bsns_year': 'fy'})
-        mapped['fy'] = mapped['fy'].astype(str)
-        mapped['fiscal_year'] = pd.to_numeric(
-            mapped['fy'], errors='coerce')
-
-        # Quarter handling.
-        qtr = mapped['quarter'].iloc[0] if (
-            'quarter' in mapped.columns
-            and mapped['quarter'].notna().any()
-        ) else 'Q4'
-        mapped['fiscal_quarter'] = qtr
-        mapped['fp'] = 'FY' if qtr == 'Q4' else qtr
-
-        # tag column (required by aggregation.py).
-        mapped['tag'] = mapped['account_nm']
-
-        # End date by quarter.
-        qtr_month = {
-            'Q1': '03-31', 'Q2': '06-30',
-            'Q3': '09-30', 'Q4': '12-31',
-        }
-        mm_dd = qtr_month.get(qtr, '12-31')
-        fy_strs = mapped['fy'].astype(str)
-        end_str = fy_strs + f'-{mm_dd}'  # type: ignore[operator]
-        mapped['end'] = pd.to_datetime(end_str)
-
-        filed_lag = 90 if qtr == 'Q4' else 45
-        mapped['filed'] = (
-            mapped['end'] + pd.Timedelta(days=filed_lag))
-
-        facts_list.append(mapped)
-
-    facts = (pd.concat(facts_list, ignore_index=True)
-             if facts_list else pd.DataFrame())
-    if not facts.empty:
-      facts['is_ytd'] = False
-
-    # For non-Q4 data, DART gives per-quarter values (not YTD).
-    # We must NOT apply YTD->Q conversion. Mark CFO/CAPEX as
-    # non-YTD by setting fp to the quarter (not 'FY').
-    # For Q4 (annual), fp='FY' triggers YTD->Q but since there's
-    # no Q3 YTD to subtract, it uses the value as-is.
-
-    # Load shares from DART shares API and forward-fill
-    # across all quarters.
-    shares_dir = bronze_dir / 'dart' / 'shares'
-    if shares_dir.exists() and not facts.empty:
-      from data.gold.screening.panel import \
-          _load_kr_shares  # pylint: disable=import-outside-toplevel
-      shares_map = _load_kr_shares(shares_dir, corp_to_stock)
-      if shares_map:
-        shares_rows: list[dict] = []  # type: ignore[type-arg]
-        for stock_code, shares_val in shares_map.items():
-          # Get all (end, fiscal_quarter) combos for this stock.
-          stock_facts = facts[facts['cik10'] == stock_code]
-          end_qtrs = stock_facts[
-              ['end', 'fiscal_quarter']].drop_duplicates()
-          for _, row in end_qtrs.iterrows():
-            fq = row['fiscal_quarter']
-            end = row['end']
-            shares_rows.append({
-                'cik10': stock_code,
-                'metric': 'SHARES',
-                'val': shares_val,
-                'end': end,
-                'filed': end + pd.Timedelta(days=45),
-                'fp': fq,
-                'fiscal_year': end.year,
-                'fiscal_quarter': fq,
-                'fy': str(end.year),
-                'tag': 'shares',
-            })
-        if shares_rows:
-          facts = pd.concat(
-              [facts, pd.DataFrame(shares_rows)],
-              ignore_index=True)
-
-    # KRX prices.
-    krx_dir = bronze_dir / 'krx' / 'daily'
-    price_list: list[pd.DataFrame] = []
-    if krx_dir.exists():
-      for csv_path in sorted(krx_dir.glob('*.csv')):
-        try:
-          pdf = pd.read_csv(csv_path, encoding='utf-8')
-          ticker = csv_path.stem
-          date_col = pdf.columns[0]
-          close_col = [c for c in pdf.columns
-                       if 'close' in c.lower()
-                       or '\uc885\uac00' in c]
-          if not close_col:
-            continue
-          out = pd.DataFrame({
-              'date': pd.to_datetime(pdf[date_col]),
-              'symbol': ticker,
-              'close': pd.to_numeric(
-                  pdf[close_col[0]], errors='coerce'),
-          })
-          price_list.append(out)
-        except Exception:  # pylint: disable=broad-except
-          continue
-
-    prices = (pd.concat(price_list, ignore_index=True)
-              if price_list else pd.DataFrame())
-
-    return facts, prices

--- a/data/gold/valuation/tests/kr_valuation_test.py
+++ b/data/gold/valuation/tests/kr_valuation_test.py
@@ -5,11 +5,10 @@ from pathlib import Path
 import pytest
 
 SILVER_DIR = Path('data/silver/out')
-BRONZE_DIR = Path('data/bronze/out')
-HAS_KR_DATA = (BRONZE_DIR / 'dart' / 'finstate').exists()
+HAS_KR_DATA = (SILVER_DIR / 'dart' / 'facts_long.parquet').exists()
 
 
-@pytest.mark.skipif(not HAS_KR_DATA, reason='No KR data')
+@pytest.mark.skipif(not HAS_KR_DATA, reason='No KR Silver data')
 class TestKRValuationPanel:
 
   def test_kia_has_quarterly_cfo_ttm(self):
@@ -20,7 +19,7 @@ class TestKRValuationPanel:
         silver_dir=SILVER_DIR,
         gold_dir=Path('/tmp/test_kr_dcf'),
         min_date='2022-01-01',
-        bronze_dir=BRONZE_DIR,
+        markets=['us', 'kr'],
     )
     panel = builder.build()
 
@@ -38,7 +37,7 @@ class TestKRValuationPanel:
         silver_dir=SILVER_DIR,
         gold_dir=Path('/tmp/test_kr_dcf2'),
         min_date='2023-01-01',
-        bronze_dir=BRONZE_DIR,
+        markets=['us', 'kr'],
     )
     panel = builder.build()
 

--- a/screening/run.py
+++ b/screening/run.py
@@ -102,9 +102,8 @@ def _add_consistency(
   return df
 
 
-def run_screening(  # pylint: disable=unused-argument
+def run_screening(
     gold_dir: Path,
-    bronze_dir: Path | None = None,
     silver_dir: Path | None = None,
     top_n: int = 30,
     min_market_cap_us: float = 2e9,
@@ -200,9 +199,6 @@ def main() -> None:
       '--silver-dir', type=Path,
       default=Path('data/silver/out'))
   parser.add_argument(
-      '--bronze-dir', type=Path,
-      default=Path('data/bronze/out'))
-  parser.add_argument(
       '--output-dir', type=Path,
       default=Path('output'))
   parser.add_argument('--top', type=int, default=50)
@@ -214,7 +210,6 @@ def main() -> None:
 
   run_screening(
       gold_dir=args.gold_dir,
-      bronze_dir=args.bronze_dir,
       silver_dir=args.silver_dir,
       top_n=args.top,
       min_market_cap_us=args.min_mcap_us,

--- a/screening/tests/run_integration_test.py
+++ b/screening/tests/run_integration_test.py
@@ -17,7 +17,6 @@ class TestRunScreening:
         run_screening  # pylint: disable=import-outside-toplevel
     df = run_screening(
         gold_dir=GOLD_DIR,
-        bronze_dir=Path('data/bronze/out'),
         silver_dir=Path('data/silver/out'),
         top_n=10,
         min_market_cap_us=2e9,
@@ -33,7 +32,6 @@ class TestRunScreening:
         run_screening  # pylint: disable=import-outside-toplevel
     df = run_screening(
         gold_dir=GOLD_DIR,
-        bronze_dir=Path('data/bronze/out'),
         silver_dir=Path('data/silver/out'),
         top_n=100,
         min_market_cap_us=2e9,


### PR DESCRIPTION
## Summary
- **Phase 3**: `MarketSource` dataclass + `BasePanelBuilder._load_data()`가 여러 시장의 Silver 데이터를 통합 로딩
- **Phase 4**: Gold에서 Bronze 직접 읽기 완전 제거 (`-402 lines`)
  - `ValuationPanelBuilder.load_kr_valuation_data()` 삭제
  - `ScreeningPanelBuilder._load_kr_data()` + `_load_kr_shares()` 삭제
  - `bronze_dir` 파라미터 → `markets=['us', 'kr']`로 교체
  - `grep -r "bronze" data/gold/` → **0건**

## Before/After
```
# Before: Gold reads Bronze directly
builder = ValuationPanelBuilder(silver_dir, gold_dir, bronze_dir=bronze_dir)

# After: Gold reads only Silver
builder = ValuationPanelBuilder(silver_dir, gold_dir, markets=['us', 'kr'])
```

## Test plan
- [x] 157개 fast test 전체 pass
- [x] pre-commit hooks (isort, pylint, yapf, mypy) 전부 pass
- [x] `grep -r "bronze" data/gold/` = 0건
- [x] `grep -r "_parse_corp_codes" data/gold/` = 0건
- [ ] `python -m data.gold.build --markets us kr` 로 패널 빌드 확인 (Silver 데이터 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)