### PR TITLE
feat: EDINET CSV extractor, multi-market screening, Gold build 3x perf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv
 **/*.json
 **/*.parquet
 **/*.csv
+**/*.zip
 **/*.png
 **/*.txt
 !example/**/*.txt

--- a/data/bronze/providers/edinet.py
+++ b/data/bronze/providers/edinet.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import csv
-from datetime import datetime
+from datetime import date
+from datetime import timedelta
 import io
+import json
 import logging
 from pathlib import Path
 import time
-from typing import Iterable
+from typing import Iterable, TYPE_CHECKING
 import zipfile
 
 import requests
@@ -19,6 +21,9 @@ from data.bronze.update import _atomic_write_bytes
 from data.bronze.update import _ensure_dir
 from data.bronze.update import _is_fresh
 from data.bronze.update import _write_meta
+
+if TYPE_CHECKING:
+  from data.bronze.cache import BronzeCache
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +37,17 @@ _DOC_DOWNLOAD_URL = (
 
 _DEFAULT_HISTORY_YEARS = 5
 
-_DOC_TYPE_ANNUAL = '120'
-_DOC_TYPE_QUARTERLY = '130'
-_DOC_TYPE_SEMIANNUAL = '140'
-_TARGET_DOC_TYPES = {_DOC_TYPE_ANNUAL, _DOC_TYPE_QUARTERLY,
-                     _DOC_TYPE_SEMIANNUAL}
+DOC_TYPE_ANNUAL = '120'
+DOC_TYPE_QUARTERLY = '130'
+DOC_TYPE_SEMIANNUAL = '140'
+TARGET_DOC_TYPES = {DOC_TYPE_ANNUAL, DOC_TYPE_QUARTERLY,
+                     DOC_TYPE_SEMIANNUAL}
+
+_CACHE_TTL_EDINET_CODES = 30
+_CACHE_TTL_XBRL = None  # historical filings are immutable
+_CACHE_TTL_DOC_LIST_RECENT = 7
+_CACHE_TTL_DOC_LIST_HISTORICAL = None
+_RECENT_DAYS_THRESHOLD = 30
 
 
 class EDINETProvider(BronzeProvider):
@@ -47,10 +58,12 @@ class EDINETProvider(BronzeProvider):
       api_key: str,
       min_interval_sec: float = 0.5,
       history_years: int = _DEFAULT_HISTORY_YEARS,
+      doc_types: set[str] | None = None,
   ) -> None:
     self._api_key = api_key
     self._min_interval = min_interval_sec
     self._history_years = history_years
+    self._doc_types = doc_types or TARGET_DOC_TYPES
 
   @property
   def name(self) -> str:
@@ -63,6 +76,7 @@ class EDINETProvider(BronzeProvider):
       *,
       refresh_days: int = 7,
       force: bool = False,
+      cache: BronzeCache | None = None,
   ) -> ProviderResult:
     edinet_dir = out_dir / 'edinet'
     _ensure_dir(edinet_dir / 'xbrl')
@@ -72,34 +86,51 @@ class EDINETProvider(BronzeProvider):
     errors: list[str] = []
 
     csv_path = edinet_dir / 'EdinetcodeDlInfo.csv'
+    csv_cache_key = 'edinet/EdinetcodeDlInfo.csv'
     if force or not _is_fresh(csv_path, refresh_days):
-      try:
-        self._fetch_edinet_codes(csv_path)
+      if (not force and cache is not None
+          and cache.resolve(csv_cache_key, csv_path,
+                            _CACHE_TTL_EDINET_CODES)):
         fetched += 1
-      except (requests.RequestException, OSError) as exc:
-        errors.append(f'edinet_codes: {exc}')
-        return ProviderResult(
-            provider_name=self.name,
-            fetched=fetched, skipped=skipped,
-            errors=errors)
+      else:
+        try:
+          self._fetch_edinet_codes(csv_path)
+          if cache is not None:
+            cache.put(csv_cache_key, csv_path.read_bytes())
+          fetched += 1
+        except (requests.RequestException, OSError) as exc:
+          errors.append(f'edinet_codes: {exc}')
+          return ProviderResult(
+              provider_name=self.name,
+              fetched=fetched, skipped=skipped,
+              errors=errors)
     else:
       skipped += 1
 
     sec_to_edinet = _parse_edinet_codes(csv_path)
 
-    tickers_list = list(tickers)
-    for ticker in tickers_list:
+    target_edinet_codes: set[str] = set()
+    edinet_to_ticker: dict[str, str] = {}
+    for ticker in tickers:
       ticker = ticker.strip()
       sec_code = f'{ticker}0' if len(ticker) == 4 else ticker
       edinet_code = sec_to_edinet.get(sec_code)
       if edinet_code is None:
         errors.append(f'Ticker not found in EDINET: {ticker}')
         continue
+      target_edinet_codes.add(edinet_code)
+      edinet_to_ticker[edinet_code] = ticker
 
+    docs_by_edinet = self._search_all_documents(
+        target_edinet_codes, cache=cache)
+
+    for edinet_code, docs in docs_by_edinet.items():
+      ticker = edinet_to_ticker.get(edinet_code, edinet_code)
       try:
-        n = self._fetch_filings_for(
-            edinet_code, edinet_dir,
-            refresh_days=refresh_days, force=force)
+        n = self._download_filings(
+            docs, edinet_code, edinet_dir,
+            refresh_days=refresh_days, force=force,
+            cache=cache)
         fetched += n
       except (requests.RequestException, OSError) as exc:
         errors.append(f'{ticker}: {exc}')
@@ -127,26 +158,119 @@ class EDINETProvider(BronzeProvider):
 
     raise ValueError('No CSV found in EDINET code zip')
 
-  def _fetch_filings_for(
+  def _search_all_documents(
       self,
+      target_edinet_codes: set[str],
+      *,
+      cache: BronzeCache | None = None,
+  ) -> dict[str, list[dict]]:
+    """Fetch doc lists by date and match all target tickers at once.
+
+    Scans every calendar day for history_years. Each date is fetched
+    once regardless of ticker count, and cached for 7 days.
+    """
+    today = date.today()
+    start = date(today.year - self._history_years, 1, 1)
+    results: dict[str, list[dict]] = {c: [] for c in target_edinet_codes}
+    seen_doc_ids: set[str] = set()
+
+    current = start
+    total_days = (today - start).days
+    api_calls = 0
+    cache_hits = 0
+
+    while current <= today:
+      date_str = current.isoformat()
+
+      doc_cache_key = f'edinet/doclist/{date_str}.json'
+      days_ago = (today - current).days
+      cache_ttl = (_CACHE_TTL_DOC_LIST_RECENT
+                   if days_ago <= _RECENT_DAYS_THRESHOLD
+                   else _CACHE_TTL_DOC_LIST_HISTORICAL)
+      cached = (cache.get_if_fresh(doc_cache_key, cache_ttl)
+                if cache is not None else None)
+      if cached is not None:
+        cache_hits += 1
+        try:
+          data = json.loads(cached)
+        except (ValueError, TypeError):
+          data = {}
+      else:
+        time.sleep(self._min_interval)
+        api_calls += 1
+
+        if api_calls % 100 == 0:
+          logger.info('EDINET doc search: %d/%d days '
+                      '(%d API, %d cache)',
+                      api_calls + cache_hits, total_days,
+                      api_calls, cache_hits)
+
+        doc_params: dict[str, str] = {
+            'date': date_str,
+            'type': '2',
+            'Subscription-Key': self._api_key,
+        }
+        resp = requests.get(
+            _DOC_LIST_URL, params=doc_params, timeout=30)
+        if not resp.ok:
+          logger.debug('EDINET API %s: %d', date_str,
+                       resp.status_code)
+          continue
+
+        try:
+          data = resp.json()
+        except (ValueError, AttributeError):
+          data = {}
+
+        if cache is not None:
+          cache.put(doc_cache_key,
+                    json.dumps(data).encode('utf-8'))
+
+      for doc in data.get('results', []):
+        doc_id = doc.get('docID', '')
+        edinet_code = doc.get('edinetCode', '')
+        if (edinet_code in target_edinet_codes
+            and doc.get('docTypeCode') in self._doc_types
+            and doc_id not in seen_doc_ids):
+          results[edinet_code].append(doc)
+          seen_doc_ids.add(doc_id)
+
+      current += timedelta(days=1)
+
+    logger.info('EDINET doc search done: %d API calls, '
+                '%d cache hits, %d docs found',
+                api_calls, cache_hits,
+                sum(len(v) for v in results.values()))
+    return results
+
+  def _download_filings(
+      self,
+      docs: list[dict],
       edinet_code: str,
       edinet_dir: Path,
       *,
       refresh_days: int,
       force: bool,
+      cache: BronzeCache | None = None,
   ) -> int:
     fetched = 0
-    doc_ids = self._search_documents(edinet_code)
 
-    for doc in doc_ids:
+    for doc in docs:
       doc_id = doc['docID']
       period_end = doc.get('periodEnd', 'unknown')
       doc_type = doc.get('docTypeCode', '')
 
-      out_path = (edinet_dir / 'xbrl'
-                  / f'{edinet_code}_{period_end}_{doc_type}.zip')
+      filename = f'{edinet_code}_{period_end}_{doc_type}.zip'
+      out_path = edinet_dir / 'xbrl' / filename
 
       if not force and _is_fresh(out_path, refresh_days):
+        continue
+
+      xbrl_cache_key = f'edinet/xbrl/{filename}'
+      if (not force and cache is not None
+          and cache.resolve(xbrl_cache_key, out_path,
+                            _CACHE_TTL_XBRL)):
+        fetched += 1
         continue
 
       time.sleep(self._min_interval)
@@ -165,54 +289,29 @@ class EDINETProvider(BronzeProvider):
           'status_code': resp.status_code,
           'nbytes': len(resp.content),
       })
+      if cache is not None:
+        cache.put(xbrl_cache_key, resp.content)
       fetched += 1
 
     return fetched
 
-  def _search_documents(self, edinet_code: str) -> list[dict]:
-    """Search EDINET document list for filings by edinet_code.
 
-    EDINET API returns filings submitted on an exact date.
-    Annual reports are typically filed ~3 months after FYE,
-    so we scan the primary filing windows (June/July for March FYE,
-    etc.) day by day.
-    """
-    now = datetime.now()
-    results: list[dict] = []
-    seen_doc_ids: set[str] = set()
+def read_edinet_code_csv(csv_path: Path) -> csv.DictReader:
+  """Read EDINET code CSV handling cp932/utf-8 and metadata header."""
+  raw = csv_path.read_bytes()
+  for encoding in ('utf-8-sig', 'cp932'):
+    try:
+      text = raw.decode(encoding)
+      break
+    except (UnicodeDecodeError, ValueError):
+      continue
+  else:
+    return csv.DictReader(io.StringIO(''))
 
-    for year_offset in range(self._history_years):
-      year = now.year - year_offset
-      for filing_month in [6, 7, 8, 11, 12, 2, 3, 5]:
-        for day in [15, 20, 25, 28]:
-          date_str = f'{year}-{filing_month:02d}-{day:02d}'
-          time.sleep(self._min_interval)
-
-          doc_params: dict[str, str] = {
-              'date': date_str,
-              'type': '2',
-              'Subscription-Key': self._api_key,
-          }
-          resp = requests.get(
-              _DOC_LIST_URL, params=doc_params, timeout=30)
-          if not resp.ok:
-            logger.debug('EDINET API %s: %d', date_str,
-                         resp.status_code)
-            continue
-
-          try:
-            data = resp.json()
-          except (ValueError, AttributeError):
-            data = {}
-          for doc in data.get('results', []):
-            doc_id = doc.get('docID', '')
-            if (doc.get('edinetCode') == edinet_code
-                and doc.get('docTypeCode') in _TARGET_DOC_TYPES
-                and doc_id not in seen_doc_ids):
-              results.append(doc)
-              seen_doc_ids.add(doc_id)
-
-    return results
+  lines = text.strip().split('\n')
+  if lines and 'ＥＤＩＮＥＴコード' not in lines[0]:
+    lines = lines[1:]
+  return csv.DictReader(io.StringIO('\n'.join(lines)))
 
 
 def _parse_edinet_codes(csv_path: Path) -> dict[str, str]:
@@ -221,12 +320,9 @@ def _parse_edinet_codes(csv_path: Path) -> dict[str, str]:
     return {}
 
   result: dict[str, str] = {}
-  text = csv_path.read_bytes().decode('utf-8-sig')
-  reader = csv.DictReader(io.StringIO(text))
-
-  for row in reader:
+  for row in read_edinet_code_csv(csv_path):
     edinet_code = (row.get('EDINET code')
-                   or row.get('EDINETコード', '')).strip()
+                   or row.get('ＥＤＩＮＥＴコード', '')).strip()
     sec_code = (row.get('Securities code')
                 or row.get('証券コード', '')).strip()
     if edinet_code and sec_code:

--- a/data/bronze/providers/tests/edinet_provider_test.py
+++ b/data/bronze/providers/tests/edinet_provider_test.py
@@ -5,6 +5,7 @@ import json
 from unittest.mock import patch
 import zipfile
 
+from data.bronze.cache import BronzeCache
 from data.bronze.providers.base import BronzeProvider
 from data.bronze.providers.base import ProviderResult
 from data.bronze.providers.edinet import EDINETProvider
@@ -143,3 +144,59 @@ class TestEDINETProviderFetch:
     assert xbrl_dir.exists()
     xbrl_files = list(xbrl_dir.glob('*.zip'))
     assert len(xbrl_files) >= 1
+
+  @patch('data.bronze.providers.edinet.requests.get')
+  def test_stores_fetched_data_in_cache(
+      self, mock_get, tmp_path):
+    zip_bytes = _make_edinet_code_zip()
+
+    def side_effect(url, **_kwargs):
+      if 'codelist' in url:
+        return _mock_response(zip_bytes)
+      if 'documents.json' in url:
+        return _mock_response(FAKE_DOC_LIST_RESPONSE)
+      return _mock_response(FAKE_XBRL_ZIP)
+
+    mock_get.side_effect = side_effect
+
+    cache = BronzeCache(cache_dir=tmp_path / 'cache')
+    provider = EDINETProvider(api_key='test', history_years=1)
+    provider.fetch(
+        ['7203'], tmp_path / 'out', refresh_days=0, force=True,
+        cache=cache)
+
+    assert cache.get_if_fresh(
+        'edinet/EdinetcodeDlInfo.csv', max_age_days=None) is not None
+    assert cache.get_if_fresh(
+        'edinet/xbrl/E02529_2025-03-31_120.zip',
+        max_age_days=None) is not None
+
+  @patch('data.bronze.providers.edinet.requests.get')
+  def test_restores_from_cache_without_api_call(
+      self, mock_get, tmp_path):
+    zip_bytes = _make_edinet_code_zip()
+
+    def side_effect(url, **_kwargs):
+      if 'codelist' in url:
+        return _mock_response(zip_bytes)
+      if 'documents.json' in url:
+        return _mock_response(FAKE_DOC_LIST_RESPONSE)
+      return _mock_response(FAKE_XBRL_ZIP)
+
+    mock_get.side_effect = side_effect
+
+    cache = BronzeCache(cache_dir=tmp_path / 'cache')
+    provider = EDINETProvider(api_key='test', history_years=1)
+
+    provider.fetch(
+        ['7203'], tmp_path / 'out1', refresh_days=0, force=True,
+        cache=cache)
+    calls_after_first = mock_get.call_count
+
+    provider.fetch(
+        ['7203'], tmp_path / 'out2', refresh_days=0, force=False,
+        cache=cache)
+
+    assert (tmp_path / 'out2' / 'edinet' / 'xbrl'
+            / 'E02529_2025-03-31_120.zip').exists()
+    assert mock_get.call_count == calls_after_first

--- a/data/bronze/update_jp.py
+++ b/data/bronze/update_jp.py
@@ -3,8 +3,18 @@ import argparse
 import os
 from pathlib import Path
 
+from data.bronze.cache import BronzeCache
+from data.bronze.providers.edinet import DOC_TYPE_ANNUAL
+from data.bronze.providers.edinet import DOC_TYPE_QUARTERLY
+from data.bronze.providers.edinet import DOC_TYPE_SEMIANNUAL
 from data.bronze.providers.edinet import EDINETProvider
 from data.bronze.providers.stooq import StooqProvider
+
+_DOC_TYPE_CHOICES = {
+    'annual': DOC_TYPE_ANNUAL,
+    'quarterly': DOC_TYPE_QUARTERLY,
+    'semiannual': DOC_TYPE_SEMIANNUAL,
+}
 
 
 def run():
@@ -26,8 +36,23 @@ def run():
   parser.add_argument(
       '--skip-prices', action='store_true',
       help='Skip Stooq price fetch')
+  parser.add_argument(
+      '--doc-types', nargs='+',
+      choices=list(_DOC_TYPE_CHOICES.keys()),
+      default=list(_DOC_TYPE_CHOICES.keys()),
+      help='Filing types to download (default: all)')
+  parser.add_argument(
+      '--cache-dir', type=Path, default=None,
+      help='Shared cache directory (default: ~/.cache/valuation/bronze/)')
+  parser.add_argument(
+      '--no-cache', action='store_true',
+      help='Disable shared cache')
 
   args = parser.parse_args()
+
+  cache = None if args.no_cache else BronzeCache(cache_dir=args.cache_dir)
+  if cache is not None:
+    print(f'[cache] {cache.cache_dir}')
 
   api_key = os.environ.get('EDINET_API_KEY', '')
   if not api_key:
@@ -35,15 +60,18 @@ def run():
         'EDINET_API_KEY is required. '
         'Get one at https://disclosure.edinet-fsa.go.jp/')
 
+  doc_types = {_DOC_TYPE_CHOICES[t] for t in args.doc_types}
   edinet = EDINETProvider(
       api_key=api_key,
-      history_years=args.history_years)
+      history_years=args.history_years,
+      doc_types=doc_types)
   print(f'Fetching EDINET filings for: {args.tickers}...')
   result = edinet.fetch(
       tickers=args.tickers,
       out_dir=args.out,
       refresh_days=0 if args.force else 7,
-      force=args.force)
+      force=args.force,
+      cache=cache)
 
   print(f'EDINET: fetched={result.fetched}, '
         f'skipped={result.skipped}')
@@ -59,7 +87,8 @@ def run():
         tickers=jp_symbols,
         out_dir=args.out,
         refresh_days=0 if args.force else 1,
-        force=args.force)
+        force=args.force,
+        cache=cache)
     print(f'Stooq JP: fetched={price_result.fetched}, '
           f'skipped={price_result.skipped}')
     if price_result.errors:

--- a/data/gold/aggregation.py
+++ b/data/gold/aggregation.py
@@ -103,54 +103,72 @@ class YTDToQuarterlyConverter:
     if df_ytd.empty:
       return pd.DataFrame()
 
-    df = df_ytd.copy()
-    df = df.sort_values('filed')
-
-    prev_fp_map = {'Q2': 'Q1', 'Q3': 'Q2', 'FY': 'Q3'}
     fp_to_fq = {'Q1': 'Q1', 'Q2': 'Q2', 'Q3': 'Q3', 'FY': 'Q4'}
+    prev_fp_map = {'Q2': 'Q1', 'Q3': 'Q2', 'FY': 'Q3'}
 
-    out_rows = []
+    df = df_ytd.copy()
+    df['fp'] = df['fp'].astype(str)
+    df['expected_fq'] = df['fp'].map(fp_to_fq)
+    df = df[df['expected_fq'] == df['fiscal_quarter']]
+    if df.empty:
+      return pd.DataFrame()
 
-    for _, row in df.iterrows():
-      fp = str(row['fp'])
-      fiscal_year = row['fiscal_year']
-      filed = row['filed']
-      ytd_val = float(row['val'])
+    df = df.sort_values('filed')
+    df['filed'] = pd.to_datetime(df['filed'])
 
-      expected_fq = fp_to_fq.get(fp)
-      if expected_fq and row.get('fiscal_quarter') != expected_fq:
-        continue
+    df['prev_fp'] = df['fp'].map(prev_fp_map)
 
-      if fp == 'Q1':
-        q_val = ytd_val
-      elif fp in prev_fp_map:
-        prev_q = prev_fp_map[fp]
-        candidates = df[(df['fiscal_year'] == fiscal_year) &
-                        (df['fp'] == prev_q) &
-                        (df['fiscal_quarter'] == prev_q) &
-                        (df['filed'] < filed)]
+    # Build prev lookup from ALL filings (pre-dedup) for PIT correctness.
+    # For each current row, find the latest prev-quarter filing
+    # that was filed BEFORE the current row's filed date.
+    prev_pool = (df[df['fp'].isin(prev_fp_map.values())]
+                 [['fiscal_year', 'fp', 'val', 'filed']]
+                 .rename(columns={'fp': 'prev_fp', 'val': '_prev_val',
+                                  'filed': '_prev_filed'})
+                 .sort_values('_prev_filed'))
 
-        if not candidates.empty:
-          prev_row = candidates.sort_values('filed').iloc[-1]
-          prev_ytd_val = float(prev_row['val'])
-          q_val = ytd_val - prev_ytd_val
-        else:
-          q_val = ytd_val
-      else:
-        continue
+    needs_prev = df[df['prev_fp'].notna()].sort_values('filed')
 
-      out_rows.append({
-          'end': row['end'],
-          'filed': row['filed'],
-          'fy': row['fy'],
-          'fp': 'Q4' if fp == 'FY' else fp,
-          'fiscal_year': fiscal_year,
-          'fiscal_quarter': expected_fq,
-          'q_val': q_val,
-          'tag': row['tag'],
-      })
+    if not needs_prev.empty and not prev_pool.empty:
+      matched = pd.merge_asof(
+          needs_prev,
+          prev_pool,
+          by=['fiscal_year', 'prev_fp'],
+          left_on='filed',
+          right_on='_prev_filed',
+          direction='backward',
+      )
+    else:
+      matched = needs_prev.copy()
+      matched['_prev_val'] = pd.NA
 
-    return pd.DataFrame(out_rows)
+    # Dedup: keep latest filing per (fiscal_year, fp)
+    df = df.drop_duplicates(
+        subset=['fiscal_year', 'fp'], keep='last')
+
+    # Q1 rows don't need subtraction
+    q1_rows = df[df['prev_fp'].isna()].copy()
+    q1_rows['q_val'] = q1_rows['val'].astype(float)
+
+    # Non-Q1 rows: use matched prev values
+    if not matched.empty:
+      non_q1 = matched.drop_duplicates(
+          subset=['fiscal_year', 'fp'], keep='last').copy()
+      non_q1['q_val'] = non_q1['val'].astype(float)
+      has_prev = non_q1['_prev_val'].notna()
+      non_q1.loc[has_prev, 'q_val'] = (
+          non_q1.loc[has_prev, 'val'].astype(float)
+          - non_q1.loc[has_prev, '_prev_val'].astype(float))
+    else:
+      non_q1 = pd.DataFrame()
+
+    merged = pd.concat([q1_rows, non_q1], ignore_index=True)
+
+    merged['fp'] = merged['fp'].replace({'FY': 'Q4'})
+    merged['fiscal_quarter'] = merged['expected_fq']
+
+    return merged[['end', 'filed', 'fy', 'fp', 'fiscal_year',
+                    'fiscal_quarter', 'q_val', 'tag']].copy()
 
 
 class TTMCalculator:

--- a/data/gold/aggregation_test.py
+++ b/data/gold/aggregation_test.py
@@ -88,6 +88,19 @@ class TestYTDToQuarterlyConverter:
     assert len(q2) == 1
     assert q2.iloc[0]['q_val'] == 250.0
 
+  def test_restated_q1_after_q2_uses_original(self):
+    """Restated Q1 filed after Q2 should not affect Q2's subtraction."""
+    facts = _make_ytd_facts('AAPL', 'CFO', [
+        {'fy': 2024, 'fp': 'Q1', 'val': 100.0, 'filed': '2024-04-15'},
+        {'fy': 2024, 'fp': 'Q2', 'val': 250.0, 'filed': '2024-07-15'},
+        {'fy': 2024, 'fp': 'Q1', 'val': 120.0, 'filed': '2024-08-01'},
+    ])
+    result = YTDToQuarterlyConverter().convert(facts)
+    q2 = result[result['fiscal_quarter'] == 'Q2']
+
+    assert len(q2) == 1
+    assert q2.iloc[0]['q_val'] == 150.0
+
   def test_non_ytd_metric_passes_through(self):
     """Non-YTD metrics (e.g., SHARES) pass val as q_val directly."""
     facts = _make_ytd_facts('AAPL', 'SHARES', [{

--- a/data/gold/backtest/panel.py
+++ b/data/gold/backtest/panel.py
@@ -27,10 +27,11 @@ class BacktestPanelBuilder(BasePanelBuilder):
       gold_dir: Path,
       min_date: Optional[str] = None,
       markets: Optional[list[str]] = None,
+      preloaded_data=None,
   ):
     super().__init__(
         silver_dir, gold_dir, BACKTEST_PANEL_SCHEMA,
-        min_date, markets)
+        min_date, markets, preloaded_data=preloaded_data)
 
   def build(self) -> pd.DataFrame:
     """Build backtest panel with all PIT versions."""
@@ -44,8 +45,11 @@ class BacktestPanelBuilder(BasePanelBuilder):
     metrics_wide = builder.merge_extra_metrics(
         metrics_q, metrics_wide)
 
+    merge_cols = ['cik10', 'ticker']
+    if 'market' in companies.columns:
+      merge_cols.append('market')
     metrics_wide = metrics_wide.merge(
-        companies[['cik10', 'ticker']],
+        companies[merge_cols],
         on='cik10',
         how='left',
     )

--- a/data/gold/build.py
+++ b/data/gold/build.py
@@ -55,6 +55,15 @@ def build_panels(
   pd.set_option('display.max_columns', None)
   pd.set_option('display.width', None)
 
+  first_builder_cls = PANEL_BUILDERS[panels[0]]
+  loader = first_builder_cls(
+      silver_dir=silver_dir, gold_dir=gold_dir,
+      min_date=min_date, markets=markets)
+  shared_data = loader.load_shared_data()
+  logger.info('Loaded shared data: companies=%d, facts=%d, prices=%d',
+              len(shared_data[0]), len(shared_data[1]),
+              len(shared_data[2]))
+
   for panel_name in panels:
     logger.info('Building: %s', panel_name)
 
@@ -68,6 +77,7 @@ def build_panels(
         gold_dir=gold_dir,
         min_date=min_date,
         markets=markets,
+        preloaded_data=shared_data,
     )
 
     panel = builder.build()

--- a/data/gold/core/base.py
+++ b/data/gold/core/base.py
@@ -74,17 +74,18 @@ class BasePanelBuilder(ABC):
       schema: PanelSchema,
       min_date: Optional[str] = None,
       markets: Optional[list[str]] = None,
+      preloaded_data: Optional[
+          tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]] = None,
   ):
     self.silver_dir = Path(silver_dir)
     self.gold_dir = Path(gold_dir)
     self.schema = schema
     self.min_date = min_date
     self.panel: Optional[pd.DataFrame] = None
+    self._preloaded_data = preloaded_data
 
     if markets is None:
       markets = ['us']
-    # Only include markets whose Silver data has been built.
-    # All panel builders require facts; skip if missing.
     self._sources: list[MarketSource] = []
     for market in markets:
       factory = MARKET_SOURCES.get(market)
@@ -97,10 +98,25 @@ class BasePanelBuilder(ABC):
   def build(self) -> pd.DataFrame:
     """Build the panel. Subclasses must implement."""
 
+  def load_shared_data(
+      self,
+  ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Load data for sharing across multiple panel builders."""
+    return self._load_data_from_sources()
+
   def _load_data(
       self,
   ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Load data from all configured market sources."""
+    if self._preloaded_data is not None:
+      return self._preloaded_data
+    return self._load_data_from_sources()
+
+  def _load_data_from_sources(
+      self,
+  ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Load data from Silver parquet files."""
+
     companies_parts: list[pd.DataFrame] = []
     facts_parts: list[pd.DataFrame] = []
     prices_parts: list[pd.DataFrame] = []

--- a/data/gold/screening/panel.py
+++ b/data/gold/screening/panel.py
@@ -51,6 +51,7 @@ class ScreeningPanelBuilder(BasePanelBuilder):
       gold_dir: Path,
       min_date: Optional[str] = None,
       markets: Optional[list[str]] = None,
+      preloaded_data=None,
   ):
     schema = PanelSchema(
         name=_SCREENING_SCHEMA_NAME,
@@ -59,7 +60,8 @@ class ScreeningPanelBuilder(BasePanelBuilder):
         primary_key=['ticker', 'end'],
     )
     super().__init__(
-        silver_dir, gold_dir, schema, min_date, markets)
+        silver_dir, gold_dir, schema, min_date, markets,
+        preloaded_data=preloaded_data)
 
   def build(self) -> pd.DataFrame:
     """Build screening panel (US + optionally KR)."""
@@ -82,8 +84,11 @@ class ScreeningPanelBuilder(BasePanelBuilder):
     wide = self._pivot_to_wide(metrics_q)
 
     # Join with company tickers.
+    merge_cols = ['cik10', 'ticker']
+    if 'market' in companies.columns:
+      merge_cols.append('market')
     wide = wide.merge(
-        companies[['cik10', 'ticker']],
+        companies[merge_cols],
         on='cik10', how='left',
     )
     wide = wide.dropna(subset=['ticker'])

--- a/data/gold/tests/transforms_test.py
+++ b/data/gold/tests/transforms_test.py
@@ -56,3 +56,60 @@ class TestPriceSymbolNormalization:
     result = join_prices_pit(metrics, prices)
     assert len(result) == 1
     assert result.iloc[0]['price'] == 152.0
+
+
+class TestJoinPricesPitEdgeCases:
+
+  def test_multiple_tickers_merged_at_once(self):
+    metrics = pd.DataFrame({
+        'ticker': ['AAPL', 'AAPL', 'TSLA'],
+        'end': pd.to_datetime(
+            ['2024-03-31', '2024-06-30', '2024-03-31']),
+        'filed': pd.to_datetime(
+            ['2024-05-01', '2024-08-01', '2024-05-15']),
+        'cfo_q': [100, 200, 50],
+    })
+    prices = pd.DataFrame({
+        'symbol': ['AAPL.US'] * 3 + ['TSLA.US'] * 3,
+        'date': pd.to_datetime(
+            ['2024-05-01', '2024-05-02', '2024-08-01',
+             '2024-05-15', '2024-05-16', '2024-08-01']),
+        'close': [170, 171, 175, 180, 181, 185],
+    })
+    result = join_prices_pit(metrics, prices)
+    assert len(result) == 3
+    assert set(result['ticker']) == {'AAPL', 'TSLA'}
+
+  def test_nat_filed_rows_preserved(self):
+    metrics = pd.DataFrame({
+        'ticker': ['AAPL', 'AAPL'],
+        'end': pd.to_datetime(['2024-03-31', '2024-06-30']),
+        'filed': [pd.Timestamp('2024-05-01'), pd.NaT],
+        'cfo_q': [100, 200],
+    })
+    prices = pd.DataFrame({
+        'symbol': ['AAPL.US'] * 2,
+        'date': pd.to_datetime(['2024-05-01', '2024-05-02']),
+        'close': [170, 171],
+    })
+    result = join_prices_pit(metrics, prices)
+    assert len(result) == 2
+    matched = result[result['price'].notna()]
+    assert len(matched) == 1
+
+  def test_unsorted_prices_handled(self):
+    metrics = pd.DataFrame({
+        'ticker': ['AAPL'],
+        'end': [pd.Timestamp('2024-06-30')],
+        'filed': [pd.Timestamp('2024-08-01')],
+        'cfo_q': [100],
+    })
+    prices = pd.DataFrame({
+        'symbol': ['AAPL.US'] * 3,
+        'date': pd.to_datetime(
+            ['2024-08-03', '2024-08-01', '2024-07-31']),
+        'close': [153, 152, 150],
+    })
+    result = join_prices_pit(metrics, prices)
+    assert len(result) == 1
+    assert result.iloc[0]['price'] == 152.0

--- a/data/gold/transforms.py
+++ b/data/gold/transforms.py
@@ -153,29 +153,44 @@ def join_prices_pit(
   prices = prices.rename(columns={'symbol': 'ticker'})
   prices['ticker'] = prices['ticker'].str.replace(r'\.\w+$', '', regex=True)
 
-  panel_parts = []
+  target_tickers = set(metrics_wide[ticker_col].unique())
+  prices = prices[prices['ticker'].isin(target_tickers)]
 
-  for ticker, ticker_metrics in metrics_wide.groupby(ticker_col):
-    ticker_prices = prices[prices['ticker'] == ticker].copy()
-    if ticker_prices.empty:
-      continue
+  has_filed = metrics_wide['filed'].notna()
+  to_merge = metrics_wide[has_filed].copy()
 
-    ticker_prices = ticker_prices.sort_values('date')
-    merged = pd.merge_asof(
-        ticker_metrics.sort_values('filed'),
-        ticker_prices[['date', 'close']],
-        left_on='filed',
-        right_on='date',
-        direction='forward',
-    )
-    merged = merged.rename(columns={'close': 'price'})
-    panel_parts.append(merged)
+  if not to_merge.empty:
+    min_filed = to_merge['filed'].min() - pd.Timedelta(days=7)
+    prices = prices[prices['date'] >= min_filed]
 
-  if not panel_parts:
+  prices = prices.sort_values('date').reset_index(drop=True)
+  to_merge = to_merge.sort_values('filed').reset_index(drop=True)
+  no_filed = metrics_wide[~has_filed]
+
+  merged = pd.merge_asof(
+      to_merge,
+      prices[['ticker', 'date', 'close']],
+      by=ticker_col,
+      left_on='filed',
+      right_on='date',
+      direction='forward',
+  )
+  merged = merged.rename(columns={'close': 'price'})
+  tickers_with_prices = set(prices['ticker'].unique())
+  merged = merged[
+      merged[ticker_col].isin(tickers_with_prices)]
+
+  if not no_filed.empty:
+    no_filed = no_filed.copy()
+    no_filed['date'] = pd.NaT
+    no_filed['price'] = pd.NA
+    merged = pd.concat([merged, no_filed], ignore_index=True)
+
+  if merged.empty:
     cols = list(metrics_wide.columns) + ['date', 'price']
     return pd.DataFrame(columns=cols)
 
-  return pd.concat(panel_parts, ignore_index=True)
+  return merged
 
 
 def calculate_market_cap(

--- a/data/gold/valuation/panel.py
+++ b/data/gold/valuation/panel.py
@@ -38,10 +38,11 @@ class ValuationPanelBuilder(BasePanelBuilder):
       gold_dir: Path,
       min_date: Optional[str] = None,
       markets: Optional[list[str]] = None,
+      preloaded_data=None,
   ):
     super().__init__(
         silver_dir, gold_dir, VALUATION_PANEL_SCHEMA,
-        min_date, markets)
+        min_date, markets, preloaded_data=preloaded_data)
 
   def build(self) -> pd.DataFrame:
     """Build valuation panel with latest version per period."""
@@ -59,8 +60,11 @@ class ValuationPanelBuilder(BasePanelBuilder):
     metrics_wide = metrics_wide.groupby(
         ['cik10', 'end'], as_index=False).tail(1)
 
+    merge_cols = ['cik10', 'ticker']
+    if 'market' in companies.columns:
+      merge_cols.append('market')
     metrics_wide = metrics_wide.merge(
-        companies[['cik10', 'ticker']],
+        companies[merge_cols],
         on='cik10',
         how='left',
     )

--- a/data/silver/sources/edinet/extractors.py
+++ b/data/silver/sources/edinet/extractors.py
@@ -1,9 +1,9 @@
-"""EDINET XBRL fact extractor."""
+"""EDINET CSV fact extractor."""
 
+import csv
 import io
 import logging
 from pathlib import Path
-from xml.etree import ElementTree
 import zipfile
 
 import pandas as pd
@@ -12,13 +12,16 @@ from data.silver.config.metric_specs_jp import METRIC_SPECS_JP
 
 logger = logging.getLogger(__name__)
 
-_NS = {
-    'xbrli': 'http://www.xbrl.org/2003/instance',
-}
+_SEGMENT_KEYWORDS = (
+    'ReportableSegmentMember',
+    'EliminationMember',
+    'OtherReportableSegmentsMember',
+    'NonConsolidatedMember',
+)
 
 
 class EDINETExtractor:
-  """Extracts financial facts from EDINET XBRL zip packages."""
+  """Extracts financial facts from EDINET CSV zip packages (type=5)."""
 
   def __init__(self) -> None:
     self._tag_to_metric = self._build_tag_index()
@@ -34,149 +37,90 @@ class EDINETExtractor:
             index[tag] = (metric, ns)
     return index
 
-  def extract_facts(self, xbrl_zip_path: Path) -> pd.DataFrame:
-    """Extract facts from an EDINET XBRL zip."""
-    xbrl_content = self._read_xbrl_from_zip(xbrl_zip_path)
-    if xbrl_content is None:
+  def extract_facts(self, zip_path: Path) -> pd.DataFrame:
+    """Extract facts from an EDINET CSV zip (type=5)."""
+    csv_content = self._read_csv_from_zip(zip_path)
+    if csv_content is None:
       return pd.DataFrame()
 
-    tree = ElementTree.parse(io.BytesIO(xbrl_content))
-    root = tree.getroot()
-
-    contexts = self._parse_contexts(root)
-    facts = self._extract_facts_from_tree(root, contexts)
-
+    facts = self._parse_csv(csv_content)
     if not facts:
       return pd.DataFrame()
 
     return pd.DataFrame(facts)
 
   @staticmethod
-  def _read_xbrl_from_zip(zip_path: Path) -> bytes | None:
+  def _read_csv_from_zip(zip_path: Path) -> str | None:
     try:
       with zipfile.ZipFile(zip_path) as zf:
         for name in zf.namelist():
-          if name.endswith('.xbrl') and 'PublicDoc' in name:
-            return zf.read(name)
-        for name in zf.namelist():
-          if name.endswith('.xbrl'):
-            return zf.read(name)
+          if 'jpcrp' in name and name.endswith('.csv'):
+            raw = zf.read(name)
+            for enc in ('utf-16', 'utf-16-le', 'cp932', 'utf-8-sig'):
+              try:
+                return raw.decode(enc)
+              except (UnicodeDecodeError, ValueError):
+                continue
     except (zipfile.BadZipFile, OSError) as exc:
-      logger.warning('Failed to read XBRL zip %s: %s',
+      logger.warning('Failed to read CSV zip %s: %s',
                      zip_path, exc)
     return None
 
-  @staticmethod
-  def _parse_contexts(
-      root: ElementTree.Element,
-  ) -> dict[str, dict]:
-    """Parse xbrli:context elements to get period info."""
-    contexts: dict[str, dict] = {}
+  def _parse_csv(self, content: str) -> list[dict]:
+    """Parse EDINET CSV and match against metric specs."""
+    reader = csv.reader(io.StringIO(content), delimiter='\t')
+    header = next(reader, None)
+    if header is None:
+      return []
 
-    for ctx in root.findall('xbrli:context', _NS):
-      ctx_id = ctx.get('id', '')
-      period = ctx.find('xbrli:period', _NS)
-      if period is None:
-        continue
-
-      entity = ctx.find('xbrli:entity', _NS)
-      identifier = None
-      if entity is not None:
-        id_el = entity.find('xbrli:identifier', _NS)
-        if id_el is not None and id_el.text:
-          identifier = id_el.text.strip()
-
-      instant = period.find('xbrli:instant', _NS)
-      end_date_el = period.find('xbrli:endDate', _NS)
-
-      if instant is not None and instant.text:
-        contexts[ctx_id] = {
-            'end': instant.text.strip(),
-            'period_type': 'instant',
-            'edinet_code': identifier,
-        }
-      elif end_date_el is not None and end_date_el.text:
-        start_el = period.find('xbrli:startDate', _NS)
-        start = start_el.text.strip() if (
-            start_el is not None and start_el.text) else None
-        contexts[ctx_id] = {
-            'end': end_date_el.text.strip(),
-            'start': start,
-            'period_type': 'duration',
-            'edinet_code': identifier,
-        }
-
-    return contexts
-
-  def _extract_facts_from_tree(
-      self,
-      root: ElementTree.Element,
-      contexts: dict[str, dict],
-  ) -> list[dict]:
-    """Walk all elements and match against metric specs."""
     facts: list[dict] = []
     seen: set[str] = set()
 
-    for elem in root.iter():
-      tag = elem.tag
-      if '}' in tag:
-        local_name = tag.split('}', 1)[1]
-      else:
-        local_name = tag
+    for row in reader:
+      if len(row) < 9:
+        continue
 
-      lookup = self._tag_to_metric.get(local_name)
+      elem_id = row[0].strip('"')
+      context_id = row[2].strip('"')
+      value_str = row[8].strip('"')
+
+      if not elem_id or not value_str:
+        continue
+
+      if any(kw in context_id for kw in _SEGMENT_KEYWORDS):
+        continue
+
+      if ':' not in elem_id:
+        continue
+      local_tag = elem_id.split(':')[1]
+
+      lookup = self._tag_to_metric.get(local_tag)
       if lookup is None:
         continue
 
       metric_name, _ = lookup
-      text = elem.text
-      if text is None:
+
+      try:
+        val = float(value_str)
+      except ValueError:
         continue
 
-      text = text.strip()
-      if not text:
-        continue
-
-      ctx_ref = elem.get('contextRef', '')
-
-      if _is_segment_or_individual_context(ctx_ref):
-        continue
-
-      ctx = contexts.get(ctx_ref, {})
-      end_date = ctx.get('end')
-      edinet_code = ctx.get('edinet_code')
-
-      dedup_key = f'{metric_name}:{ctx_ref}'
+      dedup_key = f'{metric_name}:{context_id}'
       if dedup_key in seen:
         continue
       seen.add(dedup_key)
 
-      try:
-        val = float(text)
-      except ValueError:
-        continue
+      period_type = ('instant' if 'Instant' in context_id
+                     else 'duration')
 
       facts.append({
-          'edinet_code': edinet_code,
+          'edinet_code': None,
           'metric': metric_name,
-          'tag': local_name,
+          'tag': local_tag,
           'val': val,
-          'end': end_date,
-          'context_ref': ctx_ref,
-          'period_type': ctx.get('period_type'),
+          'end': None,
+          'context_ref': context_id,
+          'period_type': period_type,
       })
 
     return facts
-
-
-_SEGMENT_KEYWORDS = (
-    'ReportableSegmentMember',
-    'EliminationMember',
-    'OtherReportableSegmentsMember',
-    'NonConsolidatedMember',
-)
-
-
-def _is_segment_or_individual_context(ctx_ref: str) -> bool:
-  """Exclude segment-level and individual (non-consolidated) contexts."""
-  return any(kw in ctx_ref for kw in _SEGMENT_KEYWORDS)

--- a/data/silver/sources/edinet/pipeline.py
+++ b/data/silver/sources/edinet/pipeline.py
@@ -1,12 +1,11 @@
-"""EDINET Silver pipeline — Bronze XBRL to Silver parquet."""
+"""EDINET Silver pipeline — Bronze CSV to Silver parquet."""
 
-import csv
-import io
 import logging
 from pathlib import Path
 
 import pandas as pd
 
+from data.bronze.providers.edinet import read_edinet_code_csv
 from data.silver.core.pipeline import Pipeline
 from data.silver.sources.edinet.extractors import EDINETExtractor
 
@@ -14,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class EDINETPipeline(Pipeline):
-  """EDINET XBRL filings → Silver facts_long + companies."""
+  """EDINET CSV filings → Silver facts_long + companies."""
 
   def extract(self) -> None:
     edinet_dir = self.context.bronze_dir / 'edinet'
@@ -25,7 +24,7 @@ class EDINETPipeline(Pipeline):
       return
 
     edinet_to_sec = self._load_code_mapping(edinet_dir)
-    facts = self._extract_all_xbrl(edinet_dir, edinet_to_sec)
+    facts = self._extract_all_filings(edinet_dir, edinet_to_sec)
 
     self.datasets['facts_long'] = facts
     self.datasets['companies'] = self._build_companies(
@@ -74,12 +73,10 @@ class EDINETPipeline(Pipeline):
       return {}
 
     result: dict[str, dict] = {}
-    text = csv_path.read_bytes().decode('utf-8-sig')
-    reader = csv.DictReader(io.StringIO(text))
 
-    for row in reader:
+    for row in read_edinet_code_csv(csv_path):
       edinet_code = (row.get('EDINET code')
-                     or row.get('EDINETコード', '')).strip()
+                     or row.get('ＥＤＩＮＥＴコード', '')).strip()
       sec_code = (row.get('Securities code')
                   or row.get('証券コード', '')).strip()
       name = (row.get('Submitter name')
@@ -104,11 +101,11 @@ class EDINETPipeline(Pipeline):
     return result
 
   @staticmethod
-  def _extract_all_xbrl(
+  def _extract_all_filings(
       edinet_dir: Path,
       edinet_to_sec: dict[str, dict],
   ) -> pd.DataFrame:
-    """Extract facts from all XBRL zips."""
+    """Extract facts from all EDINET CSV zips."""
     xbrl_dir = edinet_dir / 'xbrl'
     if not xbrl_dir.exists():
       return pd.DataFrame()
@@ -130,8 +127,8 @@ class EDINETPipeline(Pipeline):
       df['cik10'] = ticker
 
       if period_end:
-        df['end'] = pd.to_datetime(df['end'])
         end_ts = pd.Timestamp(period_end)
+        df['end'] = end_ts
         year = end_ts.year
         month = end_ts.month
 

--- a/screening/run.py
+++ b/screening/run.py
@@ -41,14 +41,14 @@ def _load_panel(gold_dir: Path) -> pd.DataFrame:
 def _load_names(
     silver_dir: Path,
 ) -> dict[str, str]:
-  """Load ticker -> company name mapping."""
+  """Load ticker -> company name mapping from all Silver sources."""
   name_map: dict[str, str] = {}
 
-  companies_path = silver_dir / 'sec' / 'companies.parquet'
-  if companies_path.exists():
+  for companies_path in sorted(silver_dir.glob('*/companies.parquet')):
     companies = pd.read_parquet(companies_path)
-    name_map.update(
-        dict(zip(companies['ticker'], companies['title'])))
+    if 'ticker' in companies.columns and 'title' in companies.columns:
+      name_map.update(
+          dict(zip(companies['ticker'], companies['title'])))
 
   return name_map
 


### PR DESCRIPTION
## Summary
- EDINET provider: date-based doc list scan with BronzeCache, doc-type CLI filter, type=5 CSV download (replaces XBRL XML)
- CSV extractor replaces XBRL XML parser — simpler, smaller files, same 12/12 metrics
- Fix cp932 encoding for real EDINET code CSV, extract shared `read_edinet_code_csv()`
- Screening: load company names from all Silver sources (not just SEC)
- Gold build optimized 3x (34min → 11min): shared data loading, vectorized `join_prices_pit`, vectorized `_ytd_to_quarter_pit` with PIT-correct restatement handling
- Add `.gitignore` entry for `*.zip`

## Test plan
- [x] 31 Gold unit tests pass (aggregation, transforms)
- [x] Pre-commit (pylint, yapf, mypy, isort) all pass
- [x] Full US+KR+JP screening produces valid results (2,186 tickers, 25 opportunity stocks)
- [x] Rubber-duck review feedback addressed (PIT restatement bug, dead code, NonConsolidatedMember filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)